### PR TITLE
Add CSV header and cleanup methods

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -4,7 +4,9 @@
 #define EVENT_CALL   (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)
 #define EVENT_RETURN (RUBY_EVENT_RETURN | RUBY_EVENT_C_RETURN)
 
-typedef enum { false, true } bool;
+#define RS_CSV_VALUES(trace) trace.event, trace.method_owner, trace.method_name, trace.filepath, trace.lineno
+#define RS_CSV_HEADER "event,method_owner,method_name,filepath,lineno\n"
+#define RS_CSV_FORMAT "%s,\"%s\",\"%s\",\"%s\",%d\n"
 
 typedef struct {
   const char* event;


### PR DESCRIPTION
Housekeeping work…

- Write a header at the top of the CSV to list the fields in use
- Open the file-handle as `w` instead of `a` (since we're writing a header now)
- Rename methods to be less ambiguous (`alloc => rs_alloc`, etc.)
- Consolidate CSV formatting/field list in `rotoscope.h`
- Only output `call`, `return` instead of `call`, `c_call`, `return`, `c_return`