### PR TITLE
Avoid writing to rotoscope log in fork

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -1,6 +1,8 @@
 #ifndef _INC_ROTOSCOPE_H_
 #define _INC_ROTOSCOPE_H_
 
+#include "unistd.h"
+
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)
 #define EVENT_RETURN (RUBY_EVENT_RETURN | RUBY_EVENT_C_RETURN)
 
@@ -29,6 +31,7 @@ typedef struct
   VALUE tracepoint;
   VALUE blacklist;
   unsigned long blacklist_size;
+  pid_t pid;
 } Rotoscope;
 
 typedef struct


### PR DESCRIPTION
cc @Shopify/componentization 

## Problem

We were getting corrupt gzip rotoscope log files which I was able to track down to a problem with the fork of the process writing to the log file.  I was able to reproduce this with the following script

```ruby
require 'rotoscope'
require 'zlib'

output_path = 'out.csv.gz'

def traced_call
end

N = 100000

Rotoscope.trace(output_path) do |rotoscope|
  fork do
    N.times { traced_call }
  end
  N.times { traced_call }
end

Process.wait

gzip = Zlib::GzipReader.open(output_path)
gzip.read
gzip.read # workaround bug where initial read doesn't check crc in footer
```

which would result in output like

```
corrupt.rb:21:in `read': invalid code lengths set (Zlib::DataError)
	from corrupt.rb:21:in `<main>'
```

or

```
corrupt.rb:22:in `read': invalid compressed data -- crc error (Zlib::GzipFile::CRCError)
	from corrupt.rb:22:in `<main>'
```

## Solution

Store the pid for the process when the Rotoscope object is initialized and check it before touching the rotoscope log file to avoid writing to it from the forked process.

## Testing

I was able to test this against the Shopify test suite using rotoscope to trace all tests and with a check after the rotoscope log is closed to make sure it isn't corrupt.  Without this change almost half the build containers found corrupt gzip and with this change I got a 🍏  CI build.