### PR TITLE
Optimize event hook

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -49,7 +49,7 @@ typedef struct
 
 typedef struct
 {
-  const char filepath[200];
+  const char *filepath;
   unsigned int lineno;
 } rs_callsite_t;
 


### PR DESCRIPTION
As mentioned in https://github.com/Shopify/rotoscope/issues/16 tracing is slow.

This PR attempts to optimize what can be optimized without reaching into ruby internals.

1. I used the properties of Thread::Backtrace::Location to get the path and line number.  I'm not sure why we were using `caller_locations` if we are just going to turn it into a string by calling `.inspect` on the locations.  An alternative would be to use `caller`, since that gives us those strings directly.

2. Use path pointer rather than copying the string

Now that we are using `Thread::Backtrace::Location#path` we shouldn't need to store a copy of the string in rs_callsite_t, we can just store a pointer to it.

3. Use tracepoint location for c return

https://github.com/Shopify/rotoscope/issues/16 has a screenshot that claims this doesn't work, but no tests fail when using the tracepoint event information rather than caller_locations to get the path and line number.  Are we just missing a test?  I never observed this inconsistency with calls to `new` or `initialize` when ruby's implementation is used.
