### PR TITLE
Don't call #to_io in #flatten for IO-like object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ rs.stop_trace
 ```
 
 #### `Rotoscope#flatten(dest)`
-Reduces the output data to a list of method invocations and their caller, instead of all `call` and `return` events. Methods invoked at the top of the trace will have a caller entity of `<ROOT>` and a caller method name of `unknown`. `dest` is either a filename or an `IO`.
+Reduces the output data to a list of method invocations and their caller, instead of all `call` and `return` events. Methods invoked at the top of the trace will have a caller entity of `<ROOT>` and a caller method name of `unknown`. `dest` is either a filename or an instance of IO, or IO-like, object.
 
 
 ```ruby

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -34,17 +34,16 @@ class Rotoscope
   end
 
   def flatten(dest)
-    io_given = false
-    dest_file = if dest.respond_to?(:to_io)
-      io_given = true
-      dest.to_io
+    io_given = if dest.respond_to?(:puts)
+      true
     else
-      File.open(dest, 'w')
+      dest = File.open(dest, 'w')
+      false
     end
 
-    flatten_into(dest_file)
+    flatten_into(dest)
   ensure
-    dest_file.close unless io_given
+    dest.close unless io_given
   end
 
   def closed?

--- a/rotoscope.gemspec
+++ b/rotoscope.gemspec
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 Gem::Specification.new do |s|
   s.name        = 'rotoscope'
-  s.version     = '0.1.0'
-  s.date        = '2016-12-13'
+  s.version     = '0.1.1'
+  s.date        = '2017-04-04'
 
   s.authors     = ["Jahfer Husain"]
   s.email       = 'jahfer.husain@shopify.com'


### PR DESCRIPTION
I realized that after attempting to use `Zlib::GzipWriter` to flatten the output into a compressed file, we were producing corrupted files that couldn't be uncompressed easily. This was due to the fact that we call `#to_io` on the passed-in object, which in the case of `Zlib::GzipWriter`, it produces a `File` object, and does not perform compression.

Solution was to not invoke `#to_io` on the object.

I've also added a test that fails with the original code:

```
  1) Error:
RotoscopeTest#test_flatten_supports_io_like_objects:
Zlib::GzipFile::Error: not in gzip format
    /Users/jahfer/src/github.com/Shopify/rotoscope/test/rotoscope_test.rb:341:in `initialize'
    /Users/jahfer/src/github.com/Shopify/rotoscope/test/rotoscope_test.rb:341:in `new'
    /Users/jahfer/src/github.com/Shopify/rotoscope/test/rotoscope_test.rb:341:in `block in unzip'
    /Users/jahfer/src/github.com/Shopify/rotoscope/test/rotoscope_test.rb:341:in `open'
    /Users/jahfer/src/github.com/Shopify/rotoscope/test/rotoscope_test.rb:341:in `unzip'
    /Users/jahfer/src/github.com/Shopify/rotoscope/test/rotoscope_test.rb:160:in `test_flatten_supports_io_like_objects'
```