### PR TITLE
Fix Rotoscope.trace with non-File IO object and no flatten

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rotoscope (0.1.0)
+    rotoscope (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Rakefile
+++ b/Rakefile
@@ -32,3 +32,5 @@ Rake::TestTask.new 'test' do |t|
   t.test_files = FileList['test/*_test.rb']
 end
 task test: :build
+
+task default: :test

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -297,13 +297,13 @@ class RotoscopeTest < MiniTest::Test
   end
 
   def test_trace_uses_io_objects
-    contents = Tempfile.open('trace') do |tracefile|
-      Rotoscope.trace(tracefile) do |rs|
-        Example.new.normal_method
-      end
-      refute_predicate tracefile, :closed?
-      tracefile.read
+    string_io = StringIO.new
+    Rotoscope.trace(string_io) do |rs|
+      Example.new.normal_method
     end
+    refute_predicate string_io, :closed?
+    assert_predicate string_io, :eof?
+    contents = string_io.string
 
     assert_equal [
       { event: "call", entity: "Example", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },


### PR DESCRIPTION
## Problem

`Rotoscope.trace(io)` only worked with a File object, since it was just getting the path for the IO object (and some don't even have a path) and writing directly to the file path.  That means that other IO objects like StringIO or Zlib::GzipWriter wouldn't work.

## Solution

I found it hard to follow `Rotoscope.trace`, since it was really an overloaded function, but the code paths were merged using conditionals instead of separated out for clarity.  So I extracted the code paths to separate functions and used private class functions for code re-use.

The actual fix I made was to use a temp file for the intermediate output, similar to when `flatten: true` is used, then the temp file is read in chunks and written to the IO file.

I separated the two code paths in Rotoscope#flatten as well for consistency.