### PR TITLE
Optimize getting caller location using some ruby internals

### DIFF
--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -1,0 +1,81 @@
+#include "ruby.h"
+#include "ruby/debug.h"
+
+#include "callsite.h"
+
+// Need the cfp field from this internal ruby structure.
+struct rb_trace_arg_struct {
+  // unused fields needed to make sure the cfp is at the
+  // correct offset
+  rb_event_flag_t unused1;
+  void *unused2;
+
+  void *cfp;
+
+  // rest of fields are unused
+};
+
+size_t ruby_control_frame_size;
+
+// We depend on MRI to store ruby control frames as an array
+// to determine the control frame size, which is used here to
+// get the caller's control frame
+static void *caller_cfp(void *cfp)
+{
+    return ((char *)cfp) + ruby_control_frame_size;
+}
+
+
+static VALUE dummy(VALUE self, VALUE first)
+{
+  if (first == Qtrue) {
+    rb_funcall(self, rb_intern("dummy"), 1, Qfalse);
+  }
+  return Qnil;
+}
+
+static void trace_control_frame_size(VALUE tpval, void *data)
+{
+  void **cfps = data;
+  rb_trace_arg_t *trace_arg = rb_tracearg_from_tracepoint(tpval);
+
+  if (cfps[0] == NULL) {
+    cfps[0] = trace_arg->cfp;
+  } else if (cfps[1] == NULL) {
+    cfps[1] = trace_arg->cfp;
+  }
+}
+
+rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg)
+{
+  VALUE path = rb_tracearg_path(trace_arg);
+  return (rs_callsite_t) {
+    .filepath = NIL_P(path) ? "" : RSTRING_PTR(path),
+    .lineno = FIX2INT(rb_tracearg_lineno(trace_arg)),
+  };
+}
+
+rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg)
+{
+  void *old_cfp = trace_arg->cfp;
+
+  // Ruby uses trace_arg->cfp to get the path and line number
+  trace_arg->cfp = caller_cfp(trace_arg->cfp);
+  rs_callsite_t callsite = c_callsite(trace_arg);
+  trace_arg->cfp = old_cfp;
+
+  return callsite;
+}
+
+void init_callsite()
+{
+  VALUE tmp_obj = rb_funcall(rb_cObject, rb_intern("new"), 0);
+  rb_define_singleton_method(tmp_obj, "dummy", dummy, 1);
+
+  char *cfps[2] = { NULL, NULL };
+  VALUE tracepoint = rb_tracepoint_new(Qnil, RUBY_EVENT_C_CALL, trace_control_frame_size, &cfps);
+  rb_tracepoint_enable(tracepoint);
+  rb_funcall(tmp_obj, rb_intern("dummy"), 1, Qtrue);
+  rb_tracepoint_disable(tracepoint);
+  ruby_control_frame_size = (size_t)cfps[0] - (size_t)cfps[1];
+}

--- a/ext/rotoscope/callsite.h
+++ b/ext/rotoscope/callsite.h
@@ -1,0 +1,15 @@
+#ifndef _INC_CALLSITE_H_
+#define _INC_CALLSITE_H_
+
+typedef struct
+{
+  const char *filepath;
+  unsigned int lineno;
+} rs_callsite_t;
+
+void init_callsite();
+
+rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg);
+rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg);
+
+#endif

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -47,10 +47,4 @@ typedef struct
   const char *method_level;
 } rs_class_desc_t;
 
-typedef struct
-{
-  const char *filepath;
-  unsigned int lineno;
-} rs_callsite_t;
-
 #endif


### PR DESCRIPTION
Fixes #16

## Problem

We want to get the caller's control frame path and line number in a trace event hook without the overhead of going through a method like `caller` or `caller_locations`.  The ruby tracepoint API only gives access to the current frames path and line number.

## Solution

Get the caller frame's path and line number by modifying the internal `cfp` field of the trace arg to point to the caller's control frame.  This means changes to this rb_trace_arg_struct struct in ruby could break the library.

The caller's control frame can be found by adding the size of a control frame to the `cfp`. The `rb_control_frame_t` is also internal to ruby, so we determine this by getting the difference between the `cfp` for two nested function calls during initialization.

Since we are depending on ruby internals, even a patch release of ruby could break this gem.  However, I did minimize the amount of internals that this patch depends on to reduce the chance of it breaking in the future.