### PR TITLE
Disable tracing on rotoscope close to avoid fprintf to NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,14 @@ rs.close
 
 #### `Rotoscope#state`
 
-Returns the current state of the Rotoscope object. Valid values are `:open`, `:closed` and `:unknown`.
+Returns the current state of the Rotoscope object. Valid values are `:open`, `:tracing`, `:closed` and `:unknown`.
 
 ```ruby
 rs = Rotoscope.new(dest)
 rs.state # :open
+rs.trace do
+  rs.state # :tracing
+end
 rs.close
 rs.state # :closed
 ```

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -17,6 +17,7 @@
 
 typedef enum {
   RS_OPEN = 1,
+  RS_TRACING,
   RS_CLOSED
 } rs_state;
 


### PR DESCRIPTION
## Problem

I was running the Shopify tests with rotoscope and found a few test containers crashed in an at_exit callback on `fprintf` in `event_hook`, where `fprintf` was being called with a NULL log.

I'm not exactly sure why, but it looks like the rotoscope log was closed before tracing had been disabled.

## Solution

Address some edges cases to avoid crashes:
* Rotoscope#close during tracing should stop tracing
* Rotoscope#close when not tracing shouldn't crash
* Initialize `config->tracepoint` in the initializer in case Rotoscope#stop_trace is called before Rotoscope#start_trace
* Disable tracing when the GC tries to deallocate the Rotoscope object, since the tracepoint doesn't hold a reference to the Rotoscope object