### PR TITLE
Copy the blacklist into an array of C strings.

### DIFF
--- a/ext/rotoscope/extconf.rb
+++ b/ext/rotoscope/extconf.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 require "mkmf"
+
+$CFLAGS << ' -std=c99 -Wall -Werror -Wno-declaration-after-statement'
 create_makefile('rotoscope/rotoscope')

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -238,9 +238,10 @@ static Rotoscope *get_config(VALUE self)
 }
 
 void copy_blacklist(Rotoscope *config, VALUE blacklist) {
+  Check_Type(blacklist, T_ARRAY);
+
   size_t blacklist_malloc_size = RARRAY_LEN(blacklist) * sizeof(*config->blacklist);
 
-  Check_Type(blacklist, T_ARRAY);
   for (long i = 0; i < RARRAY_LEN(blacklist); i++) {
     VALUE ruby_string = RARRAY_AREF(blacklist, i);
     Check_Type(ruby_string, T_STRING);

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -36,7 +36,7 @@ typedef struct
   FILE *log;
   char *log_path;
   VALUE tracepoint;
-  VALUE blacklist;
+  const char **blacklist;
   unsigned long blacklist_size;
   pid_t pid;
   rs_state state;

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -346,12 +346,6 @@ class RotoscopeTest < MiniTest::Test
   end
 
   def test_gc_rotoscope_without_stop_trace_does_not_crash
-    # Temporary workaround for a crash that occassionally happens when rotoscope
-    # is still tracing its blacklist has been garbage collected and a trace event
-    # occurs in the Tempfile finalizer. This GC.start garbage collects any Tempfile
-    # objects so this doesn't happen, but can be removed once this bug is fixed.
-    GC.start
-
     rs = Rotoscope.new(@logfile)
     rs.start_trace
     rs = nil


### PR DESCRIPTION
## Problem

The blacklist ruby array could get garbage collected before the rotoscope object while tracing is still enabled.  I made my original analysis of a crash caused by this in  https://github.com/Shopify/rotoscope/pull/21#discussion_r110200335

## Solution

Copy the ruby strings into ruby_xmalloc allocated memory so that we can make sure it isn't freed before the Rotoscope object is deallocated.