### PR TITLE
Fix undefined behaviour with use of ruby strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ rs.close
 
 #### `Rotoscope#state`
 
-Returns the current state of the Rotoscope object. Valid values are `:open`, `:tracing`, `:closed` and `:unknown`.
+Returns the current state of the Rotoscope object. Valid values are `:open`, `:tracing` and `:closed`.
 
 ```ruby
 rs = Rotoscope.new(dest)

--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -3,6 +3,8 @@
 
 #include "callsite.h"
 
+VALUE empty_ruby_string;
+
 // Need the cfp field from this internal ruby structure.
 struct rb_trace_arg_struct {
   // unused fields needed to make sure the cfp is at the
@@ -50,7 +52,7 @@ rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg)
 {
   VALUE path = rb_tracearg_path(trace_arg);
   return (rs_callsite_t) {
-    .filepath = NIL_P(path) ? "" : RSTRING_PTR(path),
+    .filepath = NIL_P(path) ? empty_ruby_string : path,
     .lineno = FIX2INT(rb_tracearg_lineno(trace_arg)),
   };
 }
@@ -69,6 +71,9 @@ rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg)
 
 void init_callsite()
 {
+  empty_ruby_string = rb_str_new_cstr("");
+  RB_OBJ_FREEZE(empty_ruby_string);
+
   VALUE tmp_obj = rb_funcall(rb_cObject, rb_intern("new"), 0);
   rb_define_singleton_method(tmp_obj, "dummy", dummy, 1);
 

--- a/ext/rotoscope/callsite.h
+++ b/ext/rotoscope/callsite.h
@@ -3,7 +3,7 @@
 
 typedef struct
 {
-  const char *filepath;
+  VALUE filepath;
   unsigned int lineno;
 } rs_callsite_t;
 

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -6,7 +6,13 @@
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)
 #define EVENT_RETURN (RUBY_EVENT_RETURN | RUBY_EVENT_C_RETURN)
 
-#define RS_CSV_VALUES(trace) trace.event, trace.entity, trace.method_name, trace.method_level, trace.filepath, trace.lineno
+#define RS_CSV_VALUES(trace) \
+    trace.event, \
+    StringValueCStr(trace.entity), \
+    StringValueCStr(trace.method_name), \
+    trace.method_level, \
+    StringValueCStr(trace.filepath), \
+    trace.lineno
 #define RS_CSV_HEADER "event,entity,method_name,method_level,filepath,lineno\n"
 #define RS_CSV_FORMAT "%s,\"%s\",\"%s\",%s,\"%s\",%d\n"
 
@@ -16,25 +22,25 @@
 #define UNKNOWN_FILE_PATH "Unknown"
 
 typedef enum {
-  RS_OPEN = 1,
+  RS_CLOSED = 0,
+  RS_OPEN,
   RS_TRACING,
-  RS_CLOSED
 } rs_state;
 
 typedef struct
 {
   const char *event;
-  const char *method_name;
-  const char *entity;
+  VALUE method_name;
+  VALUE entity;
   const char *method_level;
-  const char *filepath;
+  VALUE filepath;
   unsigned int lineno;
 } rs_tracepoint_t;
 
 typedef struct
 {
   FILE *log;
-  char *log_path;
+  VALUE log_path;
   VALUE tracepoint;
   const char **blacklist;
   unsigned long blacklist_size;
@@ -44,7 +50,7 @@ typedef struct
 
 typedef struct
 {
-  const char *name;
+  VALUE name;
   const char *method_level;
 } rs_class_desc_t;
 

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -352,6 +352,12 @@ class RotoscopeTest < MiniTest::Test
     GC.start
   end
 
+  def test_log_path
+    rs = Rotoscope.new(File.expand_path('tmp/test.csv.gz'))
+    GC.start
+    assert_equal File.expand_path('tmp/test.csv.gz'), rs.log_path
+  end
+
   private
 
   def parse_and_normalize(csv_string)


### PR DESCRIPTION
Based off of https://github.com/Shopify/rotoscope/pull/23 to avoid merge conflicts, see https://github.com/Shopify/rotoscope/compare/c-blacklist...string-safety for this PRs changes

The C code was assuming a RSTRING_PTR holds a null terminated C string.  However, the ruby extension documentation for RSTRING_PTR says

> Note that the result pointer may not be NUL-terminated

If we want a null terminated string from a ruby string, then we need to use StringValueCStr.

Rotoscope was also holding onto a bunch of RSTRING_PTR pointers, but that doesn't prevent the pointers from being garbage collected.  It is safer to hold onto the VALUE for the ruby string, then get the c string where needed.  This also allows us to mark the log_path string value, which otherwise could get garbage collected.

I've also gotten rid of the unclear unknown rotoscope state.  Instead, the state is initialized to the RS_CLOSED state by making that the `0` state.  I've tried to make sure Rotoscope.allocate returns an object that is in a good default state.