### PR TITLE
Fix dealloc on process exit in tracing state

### DIFF
--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -10,11 +10,6 @@ require 'csv'
 require 'fixture_inner'
 require 'fixture_outer'
 
-# For some reason an object finalizer is causing CI to exit with status 1
-# without any messages if it happens after minitest calls `exit`.  This will
-# workaround it for now
-Minitest.after_run { GC.start }
-
 class Example
   class << self
     def singleton_method

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -2,7 +2,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift File.expand_path('../', __FILE__)
 require 'rotoscope'
-require 'minitest/autorun'
+require 'minitest'
 require 'zlib'
 require 'fileutils'
 require 'csv'
@@ -347,6 +347,15 @@ class RotoscopeTest < MiniTest::Test
     GC.start
   end
 
+  def test_gc_rotoscope_without_stop_trace_does_not_break_process_cleanup
+    child_pid = fork do
+      rs = Rotoscope.new(@logfile)
+      rs.start_trace
+    end
+    Process.waitpid(child_pid)
+    assert_equal true, $?.success?
+  end
+
   def test_log_path
     rs = Rotoscope.new(File.expand_path('tmp/test.csv.gz'))
     GC.start
@@ -377,3 +386,7 @@ class RotoscopeTest < MiniTest::Test
     File.open(path) { |f| Zlib::GzipReader.new(f).read }
   end
 end
+
+# https://github.com/seattlerb/minitest/pull/683 needed to use
+# autorun without affecting the exit status of forked processes
+Minitest.run(ARGV)


### PR DESCRIPTION
## Problem

Were were getting CI failures with

```
rake aborted!
Command failed with status (1)
```

and no test failures or other indications of failures, which I worked around with 1182fbb9c1c6331c60a6c6d7258db77f7399dfcf

This was caused by an error late in the ruby process cleanup where we where `rs_dealloc` was calling `rb_tracepoint_disable(config->tracepoint)` after `config->tracepoint`.  Normally we can rely on the `config->state` to tell us if we are still tracing, but event hooks are removed during process cleanup, so the tracepoint object can get garbage collected before `rs_dealloc` is called.

## Solution

When the tracepoint object is garbage collected, it's type gets changed to `T_NONE`, so we can do a sanity check to make sure its type is `T_DATA` and its klass is still TracePoint before calling `rb_tracepoint_disable(config->tracepoint)`.