### PR TITLE
Register the empty string global variable since it holds a ruby object

### DIFF
--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -71,8 +71,9 @@ rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg)
 
 void init_callsite()
 {
-  empty_ruby_string = rb_str_new_cstr("");
+  empty_ruby_string = rb_str_new_literal("");
   RB_OBJ_FREEZE(empty_ruby_string);
+  rb_global_variable(&empty_ruby_string);
 
   VALUE tmp_obj = rb_funcall(rb_cObject, rb_intern("new"), 0);
   rb_define_singleton_method(tmp_obj, "dummy", dummy, 1);


### PR DESCRIPTION
## Problem

We were seeing some exceptions and crashes on `StringValueCStr(path)` in `rejected_path`.  Using a debugging I found that the `path` was `empty_string_value` but wasn't a string value anymore.  Since we didn't register the global variable, I think the empty string object was garbage collected, then the memory was re-used for something else.

## Solution

Use `rb_global_variable` to register the global variable so it isn't garbage collected.

I also found `rb_str_new_literal` which is meant for creating a string from a c string literal.