### PR TITLE
Inline "flatten" logic in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,16 @@ Writes all calls and returns of methods to `dest`, except for those whose filepa
 ```ruby
 Rotoscope.trace(dest) { |rs| ... }
 # or...
-Rotoscope.trace(dest, blacklist: ["/.gem/", "/gems/"], flatten: true) { |rs| ... }
+Rotoscope.trace(dest, blacklist: ["/.gem/"], flatten: true) { |rs| ... }
 ```
 
-#### `Rotoscope::new(dest, blacklist=[])`
+#### `Rotoscope::new(dest, blacklist: [], flatten: false)`
 
-Similar to `Rotoscope::trace`, but allows fine-grain control with `Rotoscope#start_trace` and `Rotoscope#stop_trace`.
+Same interface as `Rotoscope::trace`, but returns a `Rotoscope` instance, allowing fine-grain control via `Rotoscope#start_trace` and `Rotoscope#stop_trace`.
 ```ruby
 rs = Rotoscope.new(dest)
 # or...
-rs = Rotoscope.new(dest, ["/.gem/", "/gems/"])
+rs = Rotoscope.new(dest, blacklist: ["/.gem/"], flatten: true)
 ```
 
 ---
@@ -159,6 +159,7 @@ rs.stop_trace
 #### `Rotoscope#flatten(dest)`
 Reduces the output data to a list of method invocations and their caller, instead of all `call` and `return` events. Methods invoked at the top of the trace will have a caller entity of `<ROOT>` and a caller method name of `unknown`. `dest` is either a filename or an instance of IO, or IO-like, object.
 
+_Note: This form is significantly slower than passing `flatten: true` to the constructor of `Rotoscope` for large trace files due to differing implementations._
 
 ```ruby
 rs = Rotoscope.new(dest)

--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ Rotoscope.trace(dest) { |rs| ... }
 Rotoscope.trace(dest, blacklist: ["/.gem/"], flatten: true) { |rs| ... }
 ```
 
-#### `Rotoscope::new(dest, blacklist: [], flatten: false)`
+#### `Rotoscope::new(dest, blacklist = [], flatten = false)`
 
 Same interface as `Rotoscope::trace`, but returns a `Rotoscope` instance, allowing fine-grain control via `Rotoscope#start_trace` and `Rotoscope#stop_trace`.
 ```ruby
 rs = Rotoscope.new(dest)
 # or...
-rs = Rotoscope.new(dest, blacklist: ["/.gem/"], flatten: true)
+rs = Rotoscope.new(dest, ["/.gem/"], true)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ IO,write,instance,example/flattened_dog.rb,11,IO,puts,instance
 
 #### `Rotoscope::trace(dest, blacklist: [], flatten: false)`
 
-Writes all calls and returns of methods to `dest`, except for those whose filepath contains any entry in `blacklist`. `dest` is either a filename or an `IO`. For details on the `flatten` option, see [`Rotoscope#flatten`](#rotoscopeflatten).
+Writes all calls and returns of methods to `dest`, except for those whose filepath contains any entry in `blacklist`. `dest` is either a filename or an `IO`. The `flatten` option reduces the output data to a list of method invocations and their caller, instead of all `call` and `return` events. Methods invoked at the top of the trace will have a caller entity of `<ROOT>` and a caller method name of `<UNKNOWN>`.
 
 ```ruby
 Rotoscope.trace(dest) { |rs| ... }
@@ -154,21 +154,6 @@ rs = Rotoscope.new(dest)
 rs.start_trace
 # code to trace...
 rs.stop_trace
-```
-
-#### `Rotoscope#flatten(dest)`
-Reduces the output data to a list of method invocations and their caller, instead of all `call` and `return` events. Methods invoked at the top of the trace will have a caller entity of `<ROOT>` and a caller method name of `unknown`. `dest` is either a filename or an instance of IO, or IO-like, object.
-
-_Note: This form is significantly slower than passing `flatten: true` to the constructor of `Rotoscope` for large trace files due to differing implementations._
-
-```ruby
-rs = Rotoscope.new(dest)
-rs.trace { |rotoscope| ... }
-rs.close
-
-rs.flatten('tmp/flattened.csv')
-# or ...
-Zlib::GzipWriter.open(dest) { |gz| rs.flatten(gz) }
 ```
 
 #### `Rotoscope#mark`

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -178,9 +178,9 @@ static bool in_fork(Rotoscope *config)
 
 static bool tracecmp(rs_tracepoint_t *a, rs_tracepoint_t *b)
 {
-  return (!strcmp(StringValueCStr(a->method_name), StringValueCStr(b->method_name)) &&
-          !strcmp(StringValueCStr(a->entity), StringValueCStr(b->entity)) &&
-          !strcmp(a->method_level, b->method_level));
+  return (!rb_str_cmp(a->method_name, b->method_name) &&
+          !rb_str_cmp(a->entity, b->entity) &&
+          a->method_level == b->method_level);
 }
 
 static void log_raw_trace(FILE *stream, rs_tracepoint_t trace)

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -19,7 +19,7 @@ static rs_class_desc_t class2str(VALUE klass);
 
 static int write_csv_header(FILE *log, const char *header)
 {
-  return fprintf(log, "%s", header);
+  return fprintf(log, "%s\n", header);
 }
 
 static const char *evflag2name(rb_event_flag_t evflag)
@@ -186,7 +186,7 @@ static bool trace_pops_stack(rs_tracepoint_t trace, rs_stack_t *stack)
 
 static void log_raw_trace(FILE *stream, rs_tracepoint_t trace)
 {
-  fprintf(stream, RS_CSV_FORMAT, RS_CSV_VALUES(trace));
+  fprintf(stream, RS_CSV_FORMAT "\n", RS_CSV_VALUES(trace));
 }
 
 static void log_stack_frame(FILE *stream, rs_stack_t *stack, rs_tracepoint_t trace, rb_event_flag_t event)
@@ -194,7 +194,7 @@ static void log_stack_frame(FILE *stream, rs_stack_t *stack, rs_tracepoint_t tra
   if (event & EVENT_CALL)
   {
     rs_stack_frame_t frame = stack_push(stack, trace);
-    fprintf(stream, RS_FLATTENED_CSV_FORMAT, RS_FLATTENED_CSV_VALUES(frame));
+    fprintf(stream, RS_FLATTENED_CSV_FORMAT "\n", RS_FLATTENED_CSV_VALUES(frame));
   }
   else if (event & EVENT_RETURN)
   {

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -323,26 +323,16 @@ void copy_blacklist(Rotoscope *config, VALUE blacklist) {
 VALUE initialize(int argc, VALUE *argv, VALUE self)
 {
   Rotoscope *config = get_config(self);
-  VALUE opts;
-  VALUE output_path;
+  VALUE output_path, blacklist, flatten;
 
-  VALUE config_flatten = false;
-  VALUE config_blacklist;
-
-  rb_scan_args(argc, argv, "1:", &output_path, &opts);
+  rb_scan_args(argc, argv, "12", &output_path, &blacklist, &flatten);
   Check_Type(output_path, T_STRING);
 
-  if (!NIL_P(opts)) {
-    Check_Type(opts, T_HASH);
-    config_blacklist = rb_hash_aref(opts, ID2SYM(rb_intern("blacklist")));
-    config_flatten = rb_hash_aref(opts, ID2SYM(rb_intern("flatten")));
-
-    if (!NIL_P(config_blacklist)) {
-      copy_blacklist(config, config_blacklist);
-    }
+  if (!NIL_P(blacklist)) {
+    copy_blacklist(config, blacklist);
   }
 
-  config->flatten_output = RTEST(config_flatten);
+  config->flatten_output = RTEST(flatten);
   config->log_path = output_path;
   config->log = fopen(StringValueCStr(config->log_path), "w");
 

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -153,7 +153,7 @@ static VALUE tracearg_method_name(rb_trace_arg_t *trace_arg)
   return rb_sym2str(rb_tracearg_method_id(trace_arg));
 }
 
-static rs_tracepoint_t extract_full_tracevals(rb_trace_arg_t *trace_arg, const rs_callsite_t *callsite)
+static rs_tracepoint_t *extract_full_tracevals(rb_trace_arg_t *trace_arg, const rs_callsite_t *callsite)
 {
   rs_class_desc_t method_owner = tracearg_class(trace_arg);
   rb_event_flag_t event_flag = rb_tracearg_event_flag(trace_arg);
@@ -161,13 +161,14 @@ static rs_tracepoint_t extract_full_tracevals(rb_trace_arg_t *trace_arg, const r
   VALUE method_name = tracearg_method_name(trace_arg);
   VALUE filepath = callsite->filepath;
 
-  return (rs_tracepoint_t){
-      .event = evflag2name(event_flag),
-      .entity = StringValueCStr(method_owner.name),
-      .method_name = StringValueCStr(method_name),
-      .method_level = method_owner.method_level,
-      .filepath = StringValueCStr(filepath),
-      .lineno = callsite->lineno};
+  return rs_tracepoint_init((rs_tracepoint_args) {
+    .event = evflag2name(event_flag),
+    .entity = StringValueCStr(method_owner.name),
+    .filepath = StringValueCStr(filepath),
+    .method_name = StringValueCStr(method_name),
+    .method_level = method_owner.method_level,
+    .lineno = callsite->lineno
+  });
 }
 
 static bool in_fork(Rotoscope *config)
@@ -182,22 +183,25 @@ static bool tracecmp(rs_tracepoint_t *a, rs_tracepoint_t *b)
           !strcmp(a->method_level, b->method_level));
 }
 
-static void log_raw_trace(FILE *stream, rs_tracepoint_t trace)
+static void log_raw_trace(FILE *stream, rs_tracepoint_t *trace)
 {
   fprintf(stream, RS_CSV_FORMAT "\n", RS_CSV_VALUES(trace));
 }
 
-static void log_stack_frame(FILE *stream, rs_stack_t *stack, rs_tracepoint_t trace, rb_event_flag_t event)
+static void log_stack_frame(FILE *stream, rs_stack_t *stack, rs_tracepoint_t *trace, rb_event_flag_t event)
 {
   if (event & EVENT_CALL)
   {
-    rs_stack_frame_t frame = stack_push(stack, trace);
+    rs_stack_frame_t frame = rs_stack_push(stack, trace);
     fprintf(stream, RS_FLATTENED_CSV_FORMAT "\n", RS_FLATTENED_CSV_VALUES(frame));
   }
   else if (event & EVENT_RETURN)
   {
-    if (tracecmp(&trace, &stack_peek(stack)->tp))
-      stack_pop(stack);
+    if (tracecmp(trace, rs_stack_peek(stack)->tp))
+    {
+      rs_stack_frame_t popped = rs_stack_pop(stack);
+      rs_tracepoint_free(popped.tp);
+    }
   }
 }
 
@@ -218,8 +222,8 @@ static void event_hook(VALUE tpval, void *data)
   if (rejected_path(trace_path.filepath, config))
     return;
 
-  rs_tracepoint_t trace = extract_full_tracevals(trace_arg, &trace_path);
-  if (!strcmp("Rotoscope", trace.entity))
+  rs_tracepoint_t *trace = extract_full_tracevals(trace_arg, &trace_path);
+  if (!strcmp("Rotoscope", trace->entity))
     return;
 
   if (config->flatten_output)
@@ -268,9 +272,9 @@ static void rs_gc_mark(Rotoscope *config)
 void rs_dealloc(Rotoscope *config)
 {
   close_log_handle(config);
-  stack_free(&config->stack);
-  free(config->blacklist);
-  free(config);
+  rs_stack_free(&config->stack);
+  xfree(config->blacklist);
+  xfree(config);
 }
 
 static VALUE rs_alloc(VALUE klass)
@@ -353,7 +357,7 @@ VALUE initialize(int argc, VALUE *argv, VALUE self)
   else
     write_csv_header(config->log, RS_CSV_HEADER);
 
-  stack_init(&config->stack, STACK_CAPACITY);
+  rs_stack_init(&config->stack, STACK_CAPACITY);
   config->state = RS_OPEN;
   return self;
 }
@@ -389,7 +393,7 @@ VALUE rotoscope_mark(VALUE self)
   Rotoscope *config = get_config(self);
   if (config->log != NULL && !in_fork(config))
   {
-    stack_reset(&config->stack, STACK_CAPACITY);
+    rs_stack_reset(&config->stack, STACK_CAPACITY);
     fprintf(config->log, "---\n");
   }
   return Qnil;

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -1,25 +1,40 @@
 #ifndef _INC_ROTOSCOPE_H_
 #define _INC_ROTOSCOPE_H_
 
-#include "unistd.h"
+#include <unistd.h>
+#include "stack.h"
 
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)
 #define EVENT_RETURN (RUBY_EVENT_RETURN | RUBY_EVENT_C_RETURN)
 
 #define RS_CSV_VALUES(trace) \
     trace.event, \
-    StringValueCStr(trace.entity), \
-    StringValueCStr(trace.method_name), \
+    trace.entity, \
+    trace.method_name, \
     trace.method_level, \
-    StringValueCStr(trace.filepath), \
+    trace.filepath, \
     trace.lineno
 #define RS_CSV_HEADER "event,entity,method_name,method_level,filepath,lineno\n"
 #define RS_CSV_FORMAT "%s,\"%s\",\"%s\",%s,\"%s\",%d\n"
+
+#define RS_FLATTENED_CSV_VALUES(frame) \
+    trace.entity, \
+    trace.method_name, \
+    trace.method_level, \
+    trace.filepath, \
+    trace.lineno, \
+    frame.caller->entity, \
+    frame.caller->method_name, \
+    frame.caller->method_level
+#define RS_FLATTENED_CSV_HEADER "entity,method_name,method_level,filepath,lineno, caller_entity, caller_method_name, caller_method_level\n"
+#define RS_FLATTENED_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d,\"%s\",\"%s\",%s\n"
 
 #define CLASS_METHOD "class"
 #define INSTANCE_METHOD "instance"
 
 #define UNKNOWN_FILE_PATH "Unknown"
+
+#define STACK_CAPACITY 500
 
 typedef enum {
   RS_CLOSED = 0,
@@ -29,23 +44,15 @@ typedef enum {
 
 typedef struct
 {
-  const char *event;
-  VALUE method_name;
-  VALUE entity;
-  const char *method_level;
-  VALUE filepath;
-  unsigned int lineno;
-} rs_tracepoint_t;
-
-typedef struct
-{
   FILE *log;
   VALUE log_path;
   VALUE tracepoint;
   const char **blacklist;
   unsigned long blacklist_size;
+  bool flatten_output;
   pid_t pid;
   rs_state state;
+  rs_stack_t stack;
 } Rotoscope;
 
 typedef struct

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -7,34 +7,31 @@
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)
 #define EVENT_RETURN (RUBY_EVENT_RETURN | RUBY_EVENT_C_RETURN)
 
-#define RS_CSV_VALUES(trace) \
-    trace.event, \
+#define CLASS_METHOD "class"
+#define INSTANCE_METHOD "instance"
+
+#define STACK_CAPACITY 500
+
+#define _RS_SHARED_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
+#define _RS_SHARED_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
+#define _RS_SHARED_CSV_VALUES(trace) \
     trace.entity, \
     trace.method_name, \
     trace.method_level, \
     trace.filepath, \
     trace.lineno
-#define RS_CSV_HEADER "event,entity,method_name,method_level,filepath,lineno\n"
-#define RS_CSV_FORMAT "%s,\"%s\",\"%s\",%s,\"%s\",%d\n"
 
+#define RS_CSV_HEADER "event," _RS_SHARED_CSV_HEADER
+#define RS_CSV_FORMAT "%s," _RS_SHARED_CSV_FORMAT
+#define RS_CSV_VALUES(trace) trace.event, _RS_SHARED_CSV_VALUES(trace)
+
+#define RS_FLATTENED_CSV_HEADER _RS_SHARED_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
+#define RS_FLATTENED_CSV_FORMAT _RS_SHARED_CSV_FORMAT ",\"%s\",\"%s\",%s"
 #define RS_FLATTENED_CSV_VALUES(frame) \
-    trace.entity, \
-    trace.method_name, \
-    trace.method_level, \
-    trace.filepath, \
-    trace.lineno, \
+    _RS_SHARED_CSV_VALUES(frame), \
     frame.caller->entity, \
     frame.caller->method_name, \
     frame.caller->method_level
-#define RS_FLATTENED_CSV_HEADER "entity,method_name,method_level,filepath,lineno, caller_entity, caller_method_name, caller_method_level\n"
-#define RS_FLATTENED_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d,\"%s\",\"%s\",%s\n"
-
-#define CLASS_METHOD "class"
-#define INSTANCE_METHOD "instance"
-
-#define UNKNOWN_FILE_PATH "Unknown"
-
-#define STACK_CAPACITY 500
 
 typedef enum {
   RS_CLOSED = 0,

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -15,23 +15,23 @@
 #define _RS_SHARED_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
 #define _RS_SHARED_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
 #define _RS_SHARED_CSV_VALUES(trace) \
-    trace.entity, \
-    trace.method_name, \
-    trace.method_level, \
-    trace.filepath, \
-    trace.lineno
+    trace->entity, \
+    trace->method_name, \
+    trace->method_level, \
+    trace->filepath, \
+    trace->lineno
 
 #define RS_CSV_HEADER "event," _RS_SHARED_CSV_HEADER
 #define RS_CSV_FORMAT "%s," _RS_SHARED_CSV_FORMAT
-#define RS_CSV_VALUES(trace) trace.event, _RS_SHARED_CSV_VALUES(trace)
+#define RS_CSV_VALUES(trace) trace->event, _RS_SHARED_CSV_VALUES(trace)
 
 #define RS_FLATTENED_CSV_HEADER _RS_SHARED_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
 #define RS_FLATTENED_CSV_FORMAT _RS_SHARED_CSV_FORMAT ",\"%s\",\"%s\",%s"
 #define RS_FLATTENED_CSV_VALUES(frame) \
     _RS_SHARED_CSV_VALUES(frame.tp), \
-    frame.caller->tp.entity, \
-    frame.caller->tp.method_name, \
-    frame.caller->tp.method_level
+    frame.caller->tp->entity, \
+    frame.caller->tp->method_name, \
+    frame.caller->tp->method_level
 
 typedef enum {
   RS_CLOSED = 0,

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -28,10 +28,10 @@
 #define RS_FLATTENED_CSV_HEADER _RS_SHARED_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
 #define RS_FLATTENED_CSV_FORMAT _RS_SHARED_CSV_FORMAT ",\"%s\",\"%s\",%s"
 #define RS_FLATTENED_CSV_VALUES(frame) \
-    _RS_SHARED_CSV_VALUES(frame), \
-    frame.caller->entity, \
-    frame.caller->method_name, \
-    frame.caller->method_level
+    _RS_SHARED_CSV_VALUES(frame.tp), \
+    frame.caller->tp.entity, \
+    frame.caller->tp.method_name, \
+    frame.caller->tp.method_level
 
 typedef enum {
   RS_CLOSED = 0,

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -15,23 +15,23 @@
 #define _RS_SHARED_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
 #define _RS_SHARED_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
 #define _RS_SHARED_CSV_VALUES(trace) \
-    trace->entity, \
-    trace->method_name, \
-    trace->method_level, \
-    trace->filepath, \
-    trace->lineno
+    StringValueCStr(trace.entity), \
+    StringValueCStr(trace.method_name), \
+    trace.method_level, \
+    StringValueCStr(trace.filepath), \
+    trace.lineno
 
 #define RS_CSV_HEADER "event," _RS_SHARED_CSV_HEADER
 #define RS_CSV_FORMAT "%s," _RS_SHARED_CSV_FORMAT
-#define RS_CSV_VALUES(trace) trace->event, _RS_SHARED_CSV_VALUES(trace)
+#define RS_CSV_VALUES(trace) trace.event, _RS_SHARED_CSV_VALUES(trace)
 
 #define RS_FLATTENED_CSV_HEADER _RS_SHARED_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
 #define RS_FLATTENED_CSV_FORMAT _RS_SHARED_CSV_FORMAT ",\"%s\",\"%s\",%s"
 #define RS_FLATTENED_CSV_VALUES(frame) \
     _RS_SHARED_CSV_VALUES(frame.tp), \
-    frame.caller->tp->entity, \
-    frame.caller->tp->method_name, \
-    frame.caller->tp->method_level
+    StringValueCStr(frame.caller->tp.entity), \
+    StringValueCStr(frame.caller->tp.method_name), \
+    frame.caller->tp.method_level
 
 typedef enum {
   RS_CLOSED = 0,

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "stack.h"
+
+rs_stack_frame_t root_context;
+
+bool stack_full(rs_stack_t *stack)
+{
+  return stack->top >= stack->capacity - 1;
+}
+
+bool stack_empty(rs_stack_t *stack)
+{
+  return stack->top < 0;
+}
+
+static void resize_buffer(rs_stack_t *stack)
+{
+  unsigned int newsize = stack->capacity * 2;
+  rs_stack_frame_t *new_contents = (rs_stack_frame_t *)malloc(sizeof(rs_stack_frame_t) * newsize);
+  memcpy(new_contents, stack->contents, sizeof(rs_stack_frame_t) * stack->capacity);
+  stack->capacity = newsize;
+  stack->contents = new_contents;
+}
+
+rs_stack_frame_t stack_push(rs_stack_t *stack, rs_tracepoint_t trace)
+{
+  if (stack_full(stack))
+  {
+    resize_buffer(stack);
+  }
+
+  rs_stack_frame_t new_frame = (rs_stack_frame_t){
+    .event = trace.event,
+    .method_name = trace.method_name,
+    .entity = trace.entity,
+    .method_level = trace.method_level,
+    .filepath = trace.filepath,
+    .lineno = trace.lineno,
+    .caller = stack_peek(stack),
+  };
+
+  stack->contents[++stack->top] = new_frame;
+  return new_frame;
+}
+
+rs_stack_frame_t stack_pop(rs_stack_t *stack)
+{
+  if (stack_empty(stack))
+  {
+    fprintf(stderr, "Stack has nothing to pop!\n");
+    exit(1);
+  }
+
+  return stack->contents[stack->top--];
+}
+
+rs_stack_frame_t *stack_peek(rs_stack_t *stack)
+{
+  if (stack_empty(stack))
+  {
+    return &root_context;
+  }
+
+  return &stack->contents[stack->top];
+}
+
+void reset_stack(rs_stack_t *stack, unsigned int capacity)
+{
+  free_stack(stack);
+  init_stack(stack, capacity);
+}
+
+void free_stack(rs_stack_t *stack)
+{
+  free(stack->contents);
+  stack->contents = NULL;
+  stack->top = -1;
+  stack->capacity = 0;
+}
+
+void init_stack(rs_stack_t *stack, unsigned int capacity)
+{
+  rs_stack_frame_t *contents;
+  root_context = (rs_stack_frame_t) {
+    .method_level = "<UNKNOWN>",
+    .method_name = "<UNKNOWN>",
+    .entity = "<ROOT>"
+  };
+
+  contents = (rs_stack_frame_t *)malloc(sizeof(rs_stack_frame_t) * capacity);
+  if (contents == NULL) {
+    fprintf(stderr, "Not enough memory to allocate stack\n");
+    exit(1);
+  }
+
+  stack->contents = contents;
+  stack->capacity = capacity;
+  stack->top = -1;
+}

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -1,69 +1,63 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "ruby.h"
 #include "stack.h"
-
-static void check_buffer(rs_stack_frame_t *contents)
-{
-  if (contents == NULL)
-  {
-    fprintf(stderr, "Not enough memory to allocate stack\n");
-    exit(1);
-  }
-}
+#include "tracepoint.h"
 
 static void insert_root_node(rs_stack_t *stack)
 {
-  rs_tracepoint_t root_trace = (rs_tracepoint_t) {
-      .entity = "<ROOT>",
-      .event = UNKNOWN_STR,
-      .method_name = UNKNOWN_STR,
-      .method_level = UNKNOWN_STR,
-      .filepath = UNKNOWN_STR,
-      .lineno = 0
-  };
-
-  stack_push(stack, root_trace);
+  char *owned_unknown_str = ALLOC_N(char, strlen(UNKNOWN_STR) + 1);
+  strcpy(owned_unknown_str, UNKNOWN_STR);
+  rs_tracepoint_t *root_trace = rs_tracepoint_init((rs_tracepoint_args) {
+    .event = owned_unknown_str,
+    .entity = "<ROOT>",
+    .filepath = owned_unknown_str,
+    .method_name = owned_unknown_str,
+    .method_level = owned_unknown_str,
+    .lineno = 0
+  });
+  rs_stack_push(stack, root_trace);
 }
 
 static void resize_buffer(rs_stack_t *stack)
 {
   unsigned int newsize = stack->capacity * 2;
-  stack->contents = realloc(stack->contents, sizeof(rs_stack_frame_t) * newsize);
-  check_buffer(stack->contents);
-
+  rs_stack_frame_t *resized_contents = REALLOC_N(stack->contents, rs_stack_frame_t, newsize);
+  stack->contents = resized_contents;
   stack->capacity = newsize;
 }
 
-bool stack_full(rs_stack_t *stack)
+bool rs_stack_full(rs_stack_t *stack)
 {
   return stack->top >= stack->capacity - 1;
 }
 
-bool stack_empty(rs_stack_t *stack)
+bool rs_stack_empty(rs_stack_t *stack)
 {
   return stack->top < 0;
 }
 
-rs_stack_frame_t stack_push(rs_stack_t *stack, rs_tracepoint_t trace)
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t *trace)
 {
-  if (stack_full(stack))
+  if (rs_stack_full(stack))
   {
     resize_buffer(stack);
   }
 
+  rs_stack_frame_t *caller = rs_stack_empty(stack) ? NULL : rs_stack_peek(stack);
   rs_stack_frame_t new_frame = (rs_stack_frame_t){
     .tp = trace,
-    .caller = stack_peek(stack)
+    .caller = caller
   };
 
   stack->contents[++stack->top] = new_frame;
   return new_frame;
 }
 
-rs_stack_frame_t stack_pop(rs_stack_t *stack)
+rs_stack_frame_t rs_stack_pop(rs_stack_t *stack)
 {
-  if (stack_empty(stack))
+  if (rs_stack_empty(stack))
   {
     fprintf(stderr, "Stack is empty!\n");
     exit(1);
@@ -72,35 +66,34 @@ rs_stack_frame_t stack_pop(rs_stack_t *stack)
   return stack->contents[stack->top--];
 }
 
-rs_stack_frame_t *stack_peek(rs_stack_t *stack)
+rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack)
 {
-  if (stack_empty(stack))
+  if (rs_stack_empty(stack))
   {
-    return NULL;
+    fprintf(stderr, "Stack is empty!\n");
+    exit(1);
   }
 
   return &stack->contents[stack->top];
 }
 
-void stack_reset(rs_stack_t *stack, unsigned int capacity)
+void rs_stack_reset(rs_stack_t *stack, unsigned int capacity)
 {
   stack->top = -1;
   insert_root_node(stack);
 }
 
-void stack_free(rs_stack_t *stack)
+void rs_stack_free(rs_stack_t *stack)
 {
-  free(stack->contents);
+  xfree(stack->contents);
   stack->contents = NULL;
   stack->top = -1;
   stack->capacity = 0;
 }
 
-void stack_init(rs_stack_t *stack, unsigned int capacity)
+void rs_stack_init(rs_stack_t *stack, unsigned int capacity)
 {
-  rs_stack_frame_t *contents = (rs_stack_frame_t *)malloc(sizeof(rs_stack_frame_t) * capacity);
-  check_buffer(contents);
-
+  rs_stack_frame_t *contents = ALLOC_N(rs_stack_frame_t, capacity);
   stack->contents = contents;
   stack->capacity = capacity;
   stack->top = -1;

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -102,8 +102,6 @@ void rs_stack_init(rs_stack_t *stack, unsigned int capacity)
 
 void rs_stack_mark(rs_stack_t *stack)
 {
-  if (rs_stack_empty(stack)) return;
-
   for (int i=0; i<=stack->top; i++)
   {
     rs_stack_frame_t frame = stack->contents[i];

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -68,8 +68,7 @@ rs_stack_frame_t *stack_peek(rs_stack_t *stack)
 
 void reset_stack(rs_stack_t *stack, unsigned int capacity)
 {
-  free_stack(stack);
-  init_stack(stack, capacity);
+  stack->top = -1;
 }
 
 void free_stack(rs_stack_t *stack)
@@ -84,9 +83,13 @@ void init_stack(rs_stack_t *stack, unsigned int capacity)
 {
   rs_stack_frame_t *contents;
   root_context = (rs_stack_frame_t) {
-    .method_level = "<UNKNOWN>",
-    .method_name = "<UNKNOWN>",
-    .entity = "<ROOT>"
+    .entity = "<ROOT>",
+    .event = UNKNOWN_STR,
+    .method_name = UNKNOWN_STR,
+    .method_level = UNKNOWN_STR,
+    .filepath = UNKNOWN_STR,
+    .lineno = 0,
+    .caller = NULL
   };
 
   contents = (rs_stack_frame_t *)malloc(sizeof(rs_stack_frame_t) * capacity);

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -7,16 +7,15 @@
 
 static void insert_root_node(rs_stack_t *stack)
 {
-  char *owned_unknown_str = ALLOC_N(char, strlen(UNKNOWN_STR) + 1);
-  strcpy(owned_unknown_str, UNKNOWN_STR);
-  rs_tracepoint_t *root_trace = rs_tracepoint_init((rs_tracepoint_args) {
-    .event = owned_unknown_str,
-    .entity = "<ROOT>",
-    .filepath = owned_unknown_str,
-    .method_name = owned_unknown_str,
-    .method_level = owned_unknown_str,
+  VALUE rb_unknown_str = rb_str_new_cstr(UNKNOWN_STR);
+  rs_tracepoint_t root_trace = (rs_tracepoint_t) {
+    .event = UNKNOWN_STR,
+    .entity = rb_str_new_cstr("<ROOT>"),
+    .filepath = rb_unknown_str,
+    .method_name = rb_unknown_str,
+    .method_level = UNKNOWN_STR,
     .lineno = 0
-  });
+  };
   rs_stack_push(stack, root_trace);
 }
 
@@ -38,7 +37,7 @@ bool rs_stack_empty(rs_stack_t *stack)
   return stack->top < 0;
 }
 
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t *trace)
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace)
 {
   if (rs_stack_full(stack))
   {
@@ -99,4 +98,15 @@ void rs_stack_init(rs_stack_t *stack, unsigned int capacity)
   stack->top = -1;
 
   insert_root_node(stack);
+}
+
+void rs_stack_mark(rs_stack_t *stack)
+{
+  if (rs_stack_empty(stack)) return;
+
+  for (int i=0; i<=stack->top; i++)
+  {
+    rs_stack_frame_t frame = stack->contents[i];
+    rs_tracepoint_mark(&frame.tp);
+  }
 }

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -1,0 +1,33 @@
+#ifndef _INC_ROTOSCOPE_STACK_H_
+#define _INC_ROTOSCOPE_STACK_H_
+#include <stdbool.h>
+#include "tracepoint.h"
+
+typedef struct rs_stack_frame_t
+{
+  const char *event;
+  const char *method_name;
+  const char *entity;
+  const char *method_level;
+  const char *filepath;
+  unsigned int lineno;
+  struct rs_stack_frame_t *caller;
+} rs_stack_frame_t;
+
+typedef struct
+{
+  int capacity;
+  int top;
+  rs_stack_frame_t *contents;
+} rs_stack_t;
+
+void init_stack(rs_stack_t *stack, unsigned int capacity);
+void reset_stack(rs_stack_t *stack, unsigned int capacity);
+void free_stack(rs_stack_t *stack);
+rs_stack_frame_t stack_push(rs_stack_t *stack, rs_tracepoint_t trace);
+bool stack_empty(rs_stack_t *stack);
+bool stack_full(rs_stack_t *stack);
+rs_stack_frame_t stack_pop(rs_stack_t *stack);
+rs_stack_frame_t *stack_peek(rs_stack_t *stack);
+
+#endif

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -7,12 +7,7 @@
 
 typedef struct rs_stack_frame_t
 {
-  const char *event;
-  const char *method_name;
-  const char *entity;
-  const char *method_level;
-  const char *filepath;
-  unsigned int lineno;
+  struct rs_tracepoint_t tp;
   struct rs_stack_frame_t *caller;
 } rs_stack_frame_t;
 
@@ -23,9 +18,9 @@ typedef struct
   rs_stack_frame_t *contents;
 } rs_stack_t;
 
-void init_stack(rs_stack_t *stack, unsigned int capacity);
-void reset_stack(rs_stack_t *stack, unsigned int capacity);
-void free_stack(rs_stack_t *stack);
+void stack_init(rs_stack_t *stack, unsigned int capacity);
+void stack_reset(rs_stack_t *stack, unsigned int capacity);
+void stack_free(rs_stack_t *stack);
 rs_stack_frame_t stack_push(rs_stack_t *stack, rs_tracepoint_t trace);
 bool stack_empty(rs_stack_t *stack);
 bool stack_full(rs_stack_t *stack);

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -3,6 +3,8 @@
 #include <stdbool.h>
 #include "tracepoint.h"
 
+#define UNKNOWN_STR "<UNKNOWN>"
+
 typedef struct rs_stack_frame_t
 {
   const char *event;

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -7,7 +7,7 @@
 
 typedef struct rs_stack_frame_t
 {
-  struct rs_tracepoint_t tp;
+  struct rs_tracepoint_t *tp;
   struct rs_stack_frame_t *caller;
 } rs_stack_frame_t;
 
@@ -18,13 +18,13 @@ typedef struct
   rs_stack_frame_t *contents;
 } rs_stack_t;
 
-void stack_init(rs_stack_t *stack, unsigned int capacity);
-void stack_reset(rs_stack_t *stack, unsigned int capacity);
-void stack_free(rs_stack_t *stack);
-rs_stack_frame_t stack_push(rs_stack_t *stack, rs_tracepoint_t trace);
-bool stack_empty(rs_stack_t *stack);
-bool stack_full(rs_stack_t *stack);
-rs_stack_frame_t stack_pop(rs_stack_t *stack);
-rs_stack_frame_t *stack_peek(rs_stack_t *stack);
+void rs_stack_init(rs_stack_t *stack, unsigned int capacity);
+void rs_stack_reset(rs_stack_t *stack, unsigned int capacity);
+void rs_stack_free(rs_stack_t *stack);
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t *trace);
+bool rs_stack_empty(rs_stack_t *stack);
+bool rs_stack_full(rs_stack_t *stack);
+rs_stack_frame_t rs_stack_pop(rs_stack_t *stack);
+rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack);
 
 #endif

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -7,7 +7,7 @@
 
 typedef struct rs_stack_frame_t
 {
-  struct rs_tracepoint_t *tp;
+  struct rs_tracepoint_t tp;
   struct rs_stack_frame_t *caller;
 } rs_stack_frame_t;
 
@@ -21,10 +21,11 @@ typedef struct
 void rs_stack_init(rs_stack_t *stack, unsigned int capacity);
 void rs_stack_reset(rs_stack_t *stack, unsigned int capacity);
 void rs_stack_free(rs_stack_t *stack);
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t *trace);
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace);
 bool rs_stack_empty(rs_stack_t *stack);
 bool rs_stack_full(rs_stack_t *stack);
 rs_stack_frame_t rs_stack_pop(rs_stack_t *stack);
 rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack);
+void rs_stack_mark(rs_stack_t *stack);
 
 #endif

--- a/ext/rotoscope/tracepoint.c
+++ b/ext/rotoscope/tracepoint.c
@@ -1,33 +1,9 @@
 #include "ruby.h"
 #include "tracepoint.h"
 
-static char *ownstr(const char *cstr)
+void rs_tracepoint_mark(rs_tracepoint_t *tracepoint)
 {
-  char *owned_str = ALLOC_N(char, strlen(cstr) + 1);
-  strcpy(owned_str, cstr);
-  return owned_str;
-}
-
-void rs_tracepoint_free(rs_tracepoint_t *tracepoint)
-{
-  xfree((char *)tracepoint->event);
-  xfree((char *)tracepoint->entity);
-  xfree((char *)tracepoint->filepath);
-  xfree((char *)tracepoint->method_name);
-  xfree((char *)tracepoint->method_level);
-
-  tracepoint->event = tracepoint->entity = tracepoint->filepath = tracepoint->method_name = tracepoint->method_level = NULL;
-}
-
-rs_tracepoint_t *rs_tracepoint_init(rs_tracepoint_args args)
-{
-  rs_tracepoint_t *trace = ALLOC(rs_tracepoint_t);
-  trace->event = ownstr(args.event);
-  trace->entity = ownstr(args.entity);
-  trace->filepath = ownstr(args.filepath);
-  trace->method_name = ownstr(args.method_name);
-  trace->method_level = ownstr(args.method_level);
-  trace->lineno = args.lineno;
-
-  return trace;
+  rb_gc_mark(tracepoint->entity);
+  rb_gc_mark(tracepoint->filepath);
+  rb_gc_mark(tracepoint->method_name);
 }

--- a/ext/rotoscope/tracepoint.c
+++ b/ext/rotoscope/tracepoint.c
@@ -1,0 +1,33 @@
+#include "ruby.h"
+#include "tracepoint.h"
+
+static char *ownstr(const char *cstr)
+{
+  char *owned_str = ALLOC_N(char, strlen(cstr) + 1);
+  strcpy(owned_str, cstr);
+  return owned_str;
+}
+
+void rs_tracepoint_free(rs_tracepoint_t *tracepoint)
+{
+  xfree((char *)tracepoint->event);
+  xfree((char *)tracepoint->entity);
+  xfree((char *)tracepoint->filepath);
+  xfree((char *)tracepoint->method_name);
+  xfree((char *)tracepoint->method_level);
+
+  tracepoint->event = tracepoint->entity = tracepoint->filepath = tracepoint->method_name = tracepoint->method_level = NULL;
+}
+
+rs_tracepoint_t *rs_tracepoint_init(rs_tracepoint_args args)
+{
+  rs_tracepoint_t *trace = ALLOC(rs_tracepoint_t);
+  trace->event = ownstr(args.event);
+  trace->entity = ownstr(args.entity);
+  trace->filepath = ownstr(args.filepath);
+  trace->method_name = ownstr(args.method_name);
+  trace->method_level = ownstr(args.method_level);
+  trace->lineno = args.lineno;
+
+  return trace;
+}

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -1,0 +1,14 @@
+#ifndef _INC_ROTOSCOPE_TRACEPOINT_H_
+#define _INC_ROTOSCOPE_TRACEPOINT_H_
+
+typedef struct
+{
+  const char *event;
+  const char *method_name;
+  const char *entity;
+  const char *method_level;
+  const char *filepath;
+  unsigned int lineno;
+} rs_tracepoint_t;
+
+#endif

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -1,7 +1,7 @@
 #ifndef _INC_ROTOSCOPE_TRACEPOINT_H_
 #define _INC_ROTOSCOPE_TRACEPOINT_H_
 
-typedef struct
+typedef struct rs_tracepoint_t
 {
   const char *event;
   const char *method_name;

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -1,14 +1,28 @@
 #ifndef _INC_ROTOSCOPE_TRACEPOINT_H_
 #define _INC_ROTOSCOPE_TRACEPOINT_H_
 
+typedef struct
+{
+  const char *event;
+  const char *entity;
+  const char *filepath;
+  const char *method_name;
+  const char *method_level;
+  unsigned int lineno;
+} rs_tracepoint_args;
+
 typedef struct rs_tracepoint_t
 {
   const char *event;
-  const char *method_name;
   const char *entity;
-  const char *method_level;
   const char *filepath;
+  const char *method_name;
+  const char *method_level;
   unsigned int lineno;
 } rs_tracepoint_t;
+
+void rs_tracepoint_free(rs_tracepoint_t *tracepoint);
+
+rs_tracepoint_t *rs_tracepoint_init(rs_tracepoint_args args);
 
 #endif

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -1,28 +1,16 @@
 #ifndef _INC_ROTOSCOPE_TRACEPOINT_H_
 #define _INC_ROTOSCOPE_TRACEPOINT_H_
 
-typedef struct
-{
-  const char *event;
-  const char *entity;
-  const char *filepath;
-  const char *method_name;
-  const char *method_level;
-  unsigned int lineno;
-} rs_tracepoint_args;
-
 typedef struct rs_tracepoint_t
 {
   const char *event;
-  const char *entity;
-  const char *filepath;
-  const char *method_name;
+  VALUE entity;
+  VALUE filepath;
+  VALUE method_name;
   const char *method_level;
   unsigned int lineno;
 } rs_tracepoint_t;
 
-void rs_tracepoint_free(rs_tracepoint_t *tracepoint);
-
-rs_tracepoint_t *rs_tracepoint_init(rs_tracepoint_args args);
+void rs_tracepoint_mark(rs_tracepoint_t *tracepoint);
 
 #endif

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -41,7 +41,7 @@ class Rotoscope
     end
 
     def event_trace(dest_path, config)
-      rs = Rotoscope.new(dest_path, config)
+      rs = Rotoscope.new(dest_path, config[:blacklist], config[:flatten])
       rs.trace { yield rs }
       rs
     ensure

--- a/rotoscope.gemspec
+++ b/rotoscope.gemspec
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 Gem::Specification.new do |s|
   s.name        = 'rotoscope'
-  s.version     = '0.1.1'
-  s.date        = '2017-04-04'
+  s.version     = '0.2.0'
+  s.date        = '2017-06-19'
 
   s.authors     = ["Jahfer Husain"]
   s.email       = 'jahfer.husain@shopify.com'

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -126,7 +126,6 @@ class RotoscopeTest < MiniTest::Test
       { entity: "Example", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
       { entity: "Example", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Example", caller_method_name: "new", caller_method_level: "class" },
       { entity: "Example", method_name: "normal_method", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
-      { entity: "Rotoscope", method_name: "stop_trace", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
     ], parse_and_normalize(contents)
 
     assert_frames_consistent contents
@@ -179,14 +178,12 @@ class RotoscopeTest < MiniTest::Test
     contents = File.read(@logfile)
 
     assert_equal [
-      { event: "return", entity: "Rotoscope", method_name: "start_trace", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "call", entity: "Example", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "call", entity: "Example", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "return", entity: "Example", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "return", entity: "Example", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "call", entity: "Example", method_name: "normal_method", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "return", entity: "Example", method_name: "normal_method", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "call", entity: "Rotoscope", method_name: "stop_trace", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
     ], parse_and_normalize(contents)
 
     assert_frames_consistent contents
@@ -285,7 +282,6 @@ class RotoscopeTest < MiniTest::Test
     assert_equal [
       { event: "call", entity: "Example", method_name: "singleton_method", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "return", entity: "Example", method_name: "singleton_method", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "call", entity: "Rotoscope", method_name: "close", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
     ], parse_and_normalize(contents)
   end
 
@@ -377,8 +373,8 @@ class RotoscopeTest < MiniTest::Test
     assert_equal csv_string.scan(/\Acall/).size, csv_string.scan(/\Areturn/).size
   end
 
-  def rotoscope_trace(*args)
-    Rotoscope.trace(@logfile, *args) { |rotoscope| yield rotoscope }
+  def rotoscope_trace(config = {})
+    Rotoscope.trace(@logfile, config) { |rotoscope| yield rotoscope }
     File.read(@logfile)
   end
 

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -40,7 +40,7 @@ OUTER_FIXTURE_PATH = File.expand_path('../fixture_outer.rb', __FILE__)
 
 class RotoscopeTest < MiniTest::Test
   def setup
-    @logfile = File.expand_path('tmp/test.csv.gz')
+    @logfile = File.expand_path('tmp/test.csv')
   end
 
   def teardown
@@ -299,6 +299,7 @@ class RotoscopeTest < MiniTest::Test
       foo = FixtureOuter.new
       foo.do_work
     end
+
     assert_equal [
       { entity: "FixtureOuter", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
       { entity: "FixtureOuter", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "FixtureOuter", caller_method_name: "new", caller_method_level: "class" },

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -301,8 +301,8 @@ class RotoscopeTest < MiniTest::Test
     assert_equal csv_string.scan(/\Acall/).size, csv_string.scan(/\Areturn/).size
   end
 
-  def rotoscope_trace(config = {})
-    Rotoscope.trace(@logfile, config) { |rotoscope| yield rotoscope }
+  def rotoscope_trace(blacklist: [], flatten: false)
+    Rotoscope.trace(@logfile, blacklist: blacklist, flatten: flatten) { |rotoscope| yield rotoscope }
     File.read(@logfile)
   end
 


### PR DESCRIPTION
This PR introduces an inlined version of the "flattening" code which collects callers and callees into a single line in the outputted CSV (see [example](https://github.com/Shopify/rotoscope#example) for details). Based on a few runs, we should see a 50-60% improvement in CI running time when using `Rotoscope` (cc @airhorns):

<img width="1153" alt="screen shot 2017-06-17 at 4 47 01 pm" src="https://user-images.githubusercontent.com/370323/27256226-a5c298e6-537c-11e7-8af8-bb6957b89a65.png">

<img width="1156" alt="screen shot 2017-06-17 at 4 46 43 pm" src="https://user-images.githubusercontent.com/370323/27256228-b4f71a94-537c-11e7-81c9-5b365cb9ec94.png">

I've never written a dynamically-allocating array stack before, so _have mercy on my soul_ 🙏 

---

I have some refactors planned to make this code cleaner, but it involves breaking up `rotoscope.c` into `logging.c` and `tracepoint.c`, and the changes here would get lost in the move. So I'll do that after and keep the code as-is for now.