### PR TITLE
Override initializer method for kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ Rotoscope.trace(dest) { |rs| ... }
 Rotoscope.trace(dest, blacklist: ["/.gem/"], flatten: true) { |rs| ... }
 ```
 
-#### `Rotoscope::new(dest, blacklist = [], flatten = false)`
+#### `Rotoscope::new(dest, blacklist: [], flatten: false)`
 
 Same interface as `Rotoscope::trace`, but returns a `Rotoscope` instance, allowing fine-grain control via `Rotoscope#start_trace` and `Rotoscope#stop_trace`.
 ```ruby
 rs = Rotoscope.new(dest)
 # or...
-rs = Rotoscope.new(dest, ["/.gem/"], true)
+rs = Rotoscope.new(dest, blacklist: ["/.gem/"], flatten: true)
 ```
 
 ---

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -6,6 +6,10 @@ require 'csv'
 
 class Rotoscope
   class << self
+    def new(output_path, blacklist: [], flatten: false)
+      super(output_path, blacklist, flatten)
+    end
+
     def trace(dest, blacklist: [], flatten: false, &block)
       config = { blacklist: blacklist, flatten: flatten }
       if dest.is_a?(String)
@@ -41,7 +45,7 @@ class Rotoscope
     end
 
     def event_trace(dest_path, config)
-      rs = Rotoscope.new(dest_path, config[:blacklist], config[:flatten])
+      rs = Rotoscope.new(dest_path, blacklist: config[:blacklist], flatten: config[:flatten])
       rs.trace { yield rs }
       rs
     ensure

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -48,7 +48,7 @@ class RotoscopeTest < MiniTest::Test
   end
 
   def test_new
-    rs = Rotoscope.new(@logfile)
+    rs = Rotoscope.new(@logfile, blacklist: ['tmp'], flatten: true)
     assert rs.is_a?(Rotoscope)
   end
 


### PR DESCRIPTION
Since implementing kwargs in C [is not very fast](https://github.com/Shopify/rotoscope/pull/28#discussion_r122821400), this is just a wrapper in Ruby to have a cleaner API on top of the C-implementation.