### PR TITLE
Apply clang-format (Google-style)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: Google

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+find $PWD -iname *.h -o -iname *.c | xargs clang-format -i -style=file

--- a/dev.yml
+++ b/dev.yml
@@ -2,8 +2,11 @@
 name: rotoscope
 up:
   - ruby: 2.3.3
+  - homebrew:
+    - clang-format
   - bundler
 
 commands:
   build: bundle exec rake build
   test: bundle exec rake test
+  fmt: bin/fmt

--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -11,9 +11,7 @@ struct rb_trace_arg_struct {
   // correct offset
   rb_event_flag_t unused1;
   void *unused2;
-
   void *cfp;
-
   // rest of fields are unused
 };
 
@@ -22,22 +20,18 @@ size_t ruby_control_frame_size;
 // We depend on MRI to store ruby control frames as an array
 // to determine the control frame size, which is used here to
 // get the caller's control frame
-static void *caller_cfp(void *cfp)
-{
-    return ((char *)cfp) + ruby_control_frame_size;
+static void *caller_cfp(void *cfp) {
+  return ((char *)cfp) + ruby_control_frame_size;
 }
 
-
-static VALUE dummy(VALUE self, VALUE first)
-{
+static VALUE dummy(VALUE self, VALUE first) {
   if (first == Qtrue) {
     rb_funcall(self, rb_intern("dummy"), 1, Qfalse);
   }
   return Qnil;
 }
 
-static void trace_control_frame_size(VALUE tpval, void *data)
-{
+static void trace_control_frame_size(VALUE tpval, void *data) {
   void **cfps = data;
   rb_trace_arg_t *trace_arg = rb_tracearg_from_tracepoint(tpval);
 
@@ -48,17 +42,15 @@ static void trace_control_frame_size(VALUE tpval, void *data)
   }
 }
 
-rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg)
-{
+rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg) {
   VALUE path = rb_tracearg_path(trace_arg);
-  return (rs_callsite_t) {
-    .filepath = NIL_P(path) ? empty_ruby_string : path,
-    .lineno = FIX2INT(rb_tracearg_lineno(trace_arg)),
+  return (rs_callsite_t){
+      .filepath = NIL_P(path) ? empty_ruby_string : path,
+      .lineno = FIX2INT(rb_tracearg_lineno(trace_arg)),
   };
 }
 
-rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg)
-{
+rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg) {
   void *old_cfp = trace_arg->cfp;
 
   // Ruby uses trace_arg->cfp to get the path and line number
@@ -69,8 +61,7 @@ rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg)
   return callsite;
 }
 
-void init_callsite()
-{
+void init_callsite() {
   empty_ruby_string = rb_str_new_literal("");
   RB_OBJ_FREEZE(empty_ruby_string);
   rb_global_variable(&empty_ruby_string);
@@ -78,8 +69,9 @@ void init_callsite()
   VALUE tmp_obj = rb_funcall(rb_cObject, rb_intern("new"), 0);
   rb_define_singleton_method(tmp_obj, "dummy", dummy, 1);
 
-  char *cfps[2] = { NULL, NULL };
-  VALUE tracepoint = rb_tracepoint_new(Qnil, RUBY_EVENT_C_CALL, trace_control_frame_size, &cfps);
+  char *cfps[2] = {NULL, NULL};
+  VALUE tracepoint = rb_tracepoint_new(Qnil, RUBY_EVENT_C_CALL,
+                                       trace_control_frame_size, &cfps);
   rb_tracepoint_enable(tracepoint);
   rb_funcall(tmp_obj, rb_intern("dummy"), 1, Qtrue);
   rb_tracepoint_disable(tracepoint);

--- a/ext/rotoscope/callsite.h
+++ b/ext/rotoscope/callsite.h
@@ -1,8 +1,7 @@
 #ifndef _INC_CALLSITE_H_
 #define _INC_CALLSITE_H_
 
-typedef struct
-{
+typedef struct {
   VALUE filepath;
   unsigned int lineno;
 } rs_callsite_t;

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -1,86 +1,74 @@
-#include "ruby.h"
-#include "ruby/version.h"
-#include "ruby/debug.h"
-#include "ruby/intern.h"
-#include <stdio.h>
+// clang-format off
+#include <ruby.h>
+#include <ruby/debug.h>
+#include <ruby/intern.h>
+#include <ruby/version.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <sys/file.h>
+// clang-format on
 
-#include "rotoscope.h"
-#include "tracepoint.h"
 #include "callsite.h"
+#include "rotoscope.h"
 #include "stack.h"
+#include "tracepoint.h"
 
 VALUE cRotoscope, cTracePoint;
 
 // recursive with singleton2str
 static rs_class_desc_t class2str(VALUE klass);
 
-static int write_csv_header(FILE *log, const char *header)
-{
+static int write_csv_header(FILE *log, const char *header) {
   return fprintf(log, "%s\n", header);
 }
 
-static const char *evflag2name(rb_event_flag_t evflag)
-{
-  switch (evflag)
-  {
-  case RUBY_EVENT_CALL:
-  case RUBY_EVENT_C_CALL:
-    return "call";
-  case RUBY_EVENT_RETURN:
-  case RUBY_EVENT_C_RETURN:
-    return "return";
-  default:
-    return "unknown";
+static const char *evflag2name(rb_event_flag_t evflag) {
+  switch (evflag) {
+    case RUBY_EVENT_CALL:
+    case RUBY_EVENT_C_CALL:
+      return "call";
+    case RUBY_EVENT_RETURN:
+    case RUBY_EVENT_C_RETURN:
+      return "return";
+    default:
+      return "unknown";
   }
 }
 
-static bool rejected_path(VALUE path, Rotoscope *config)
-{
-  for (unsigned long i = 0; i < config->blacklist_size; i++)
-  {
-    if (strstr(StringValueCStr(path), config->blacklist[i]))
-      return true;
+static bool rejected_path(VALUE path, Rotoscope *config) {
+  for (unsigned long i = 0; i < config->blacklist_size; i++) {
+    if (strstr(StringValueCStr(path), config->blacklist[i])) return true;
   }
 
   return false;
 }
 
-static VALUE class_of_singleton(VALUE klass)
-{
+static VALUE class_of_singleton(VALUE klass) {
   return rb_iv_get(klass, "__attached__");
 }
 
-static bool is_class_singleton(VALUE klass)
-{
+static bool is_class_singleton(VALUE klass) {
   VALUE obj = class_of_singleton(klass);
   return (RB_TYPE_P(obj, T_MODULE) || RB_TYPE_P(obj, T_CLASS));
 }
 
-static VALUE singleton2str(VALUE klass)
-{
-  if (is_class_singleton(klass))
-  {
+static VALUE singleton2str(VALUE klass) {
+  if (is_class_singleton(klass)) {
     VALUE obj = class_of_singleton(klass);
     VALUE cached_lookup = rb_class_path_cached(obj);
     VALUE name = (NIL_P(cached_lookup)) ? rb_class_name(obj) : cached_lookup;
     return name;
-  }
-  else // singleton of an instance
+  } else  // singleton of an instance
   {
     VALUE real_klass;
     VALUE ancestors = rb_mod_ancestors(klass);
-    if (RARRAY_LEN(ancestors) > 0 && !NIL_P(real_klass = rb_ary_entry(ancestors, 1)))
-    {
+    if (RARRAY_LEN(ancestors) > 0 &&
+        !NIL_P(real_klass = rb_ary_entry(ancestors, 1))) {
       VALUE cached_lookup = rb_class_path_cached(real_klass);
-      if (RTEST(cached_lookup))
-      {
+      if (RTEST(cached_lookup)) {
         return cached_lookup;
-      }
-      else
-      {
+      } else {
         return rb_class_name(real_klass);
       }
     }
@@ -90,28 +78,20 @@ static VALUE singleton2str(VALUE klass)
   }
 }
 
-static rs_class_desc_t class2str(VALUE klass)
-{
+static rs_class_desc_t class2str(VALUE klass) {
   rs_class_desc_t real_class;
   real_class.method_level = INSTANCE_METHOD;
 
   VALUE cached_lookup = rb_class_path_cached(klass);
-  if (RTEST(cached_lookup))
-  {
+  if (RTEST(cached_lookup)) {
     real_class.name = cached_lookup;
-  }
-  else
-  {
-    if (FL_TEST(klass, FL_SINGLETON))
-    {
+  } else {
+    if (FL_TEST(klass, FL_SINGLETON)) {
       real_class.name = singleton2str(klass);
-      if (is_class_singleton(klass))
-      {
+      if (is_class_singleton(klass)) {
         real_class.method_level = CLASS_METHOD;
       }
-    }
-    else
-    {
+    } else {
       real_class.name = rb_class_path(klass);
     }
   }
@@ -119,95 +99,77 @@ static rs_class_desc_t class2str(VALUE klass)
   return real_class;
 }
 
-static rs_callsite_t tracearg_path(rb_trace_arg_t *trace_arg)
-{
-  switch (rb_tracearg_event_flag(trace_arg))
-  {
-  case RUBY_EVENT_C_RETURN:
-  case RUBY_EVENT_C_CALL:
-    return c_callsite(trace_arg);
-  default:
-    return ruby_callsite(trace_arg);
+static rs_callsite_t tracearg_path(rb_trace_arg_t *trace_arg) {
+  switch (rb_tracearg_event_flag(trace_arg)) {
+    case RUBY_EVENT_C_RETURN:
+    case RUBY_EVENT_C_CALL:
+      return c_callsite(trace_arg);
+    default:
+      return ruby_callsite(trace_arg);
   }
 }
 
-static rs_class_desc_t tracearg_class(rb_trace_arg_t *trace_arg)
-{
+static rs_class_desc_t tracearg_class(rb_trace_arg_t *trace_arg) {
   VALUE klass;
   VALUE self = rb_tracearg_self(trace_arg);
 
-  if (RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_OBJECT) || RB_TYPE_P(self, T_CLASS))
-  {
+  if (RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_OBJECT) ||
+      RB_TYPE_P(self, T_CLASS)) {
     klass = RBASIC_CLASS(self);
-  }
-  else
-  {
+  } else {
     klass = rb_tracearg_defined_class(trace_arg);
   }
 
   return class2str(klass);
 }
 
-static VALUE tracearg_method_name(rb_trace_arg_t *trace_arg)
-{
+static VALUE tracearg_method_name(rb_trace_arg_t *trace_arg) {
   return rb_sym2str(rb_tracearg_method_id(trace_arg));
 }
 
-static rs_tracepoint_t extract_full_tracevals(rb_trace_arg_t *trace_arg, const rs_callsite_t *callsite)
-{
+static rs_tracepoint_t extract_full_tracevals(rb_trace_arg_t *trace_arg,
+                                              const rs_callsite_t *callsite) {
   rs_class_desc_t method_owner = tracearg_class(trace_arg);
   rb_event_flag_t event_flag = rb_tracearg_event_flag(trace_arg);
 
   VALUE method_name = tracearg_method_name(trace_arg);
   VALUE filepath = callsite->filepath;
 
-  return (rs_tracepoint_t) {
-    .event = evflag2name(event_flag),
-    .entity = method_owner.name,
-    .filepath = filepath,
-    .method_name = method_name,
-    .method_level = method_owner.method_level,
-    .lineno = callsite->lineno
-  };
+  return (rs_tracepoint_t){.event = evflag2name(event_flag),
+                           .entity = method_owner.name,
+                           .filepath = filepath,
+                           .method_name = method_name,
+                           .method_level = method_owner.method_level,
+                           .lineno = callsite->lineno};
 }
 
-static bool in_fork(Rotoscope *config)
-{
-  return config->pid != getpid();
-}
+static bool in_fork(Rotoscope *config) { return config->pid != getpid(); }
 
-static bool tracecmp(rs_tracepoint_t *a, rs_tracepoint_t *b)
-{
+static bool tracecmp(rs_tracepoint_t *a, rs_tracepoint_t *b) {
   return (!rb_str_cmp(a->method_name, b->method_name) &&
           !rb_str_cmp(a->entity, b->entity) &&
           a->method_level == b->method_level);
 }
 
-static void log_raw_trace(FILE *stream, rs_tracepoint_t trace)
-{
+static void log_raw_trace(FILE *stream, rs_tracepoint_t trace) {
   fprintf(stream, RS_CSV_FORMAT "\n", RS_CSV_VALUES(trace));
 }
 
-static void log_stack_frame(FILE *stream, rs_stack_t *stack, rs_tracepoint_t trace, rb_event_flag_t event)
-{
-  if (event & EVENT_CALL)
-  {
+static void log_stack_frame(FILE *stream, rs_stack_t *stack,
+                            rs_tracepoint_t trace, rb_event_flag_t event) {
+  if (event & EVENT_CALL) {
     rs_stack_frame_t frame = rs_stack_push(stack, trace);
-    fprintf(stream, RS_FLATTENED_CSV_FORMAT "\n", RS_FLATTENED_CSV_VALUES(frame));
-  }
-  else if (event & EVENT_RETURN)
-  {
-    if (tracecmp(&trace, &rs_stack_peek(stack)->tp))
-      rs_stack_pop(stack);
+    fprintf(stream, RS_FLATTENED_CSV_FORMAT "\n",
+            RS_FLATTENED_CSV_VALUES(frame));
+  } else if (event & EVENT_RETURN) {
+    if (tracecmp(&trace, &rs_stack_peek(stack)->tp)) rs_stack_pop(stack);
   }
 }
 
-static void event_hook(VALUE tpval, void *data)
-{
+static void event_hook(VALUE tpval, void *data) {
   Rotoscope *config = (Rotoscope *)data;
 
-  if (in_fork(config))
-  {
+  if (in_fork(config)) {
     rb_tracepoint_disable(config->tracepoint);
     config->state = RS_OPEN;
     return;
@@ -216,77 +178,66 @@ static void event_hook(VALUE tpval, void *data)
   rb_trace_arg_t *trace_arg = rb_tracearg_from_tracepoint(tpval);
   rs_callsite_t trace_path = tracearg_path(trace_arg);
 
-  if (rejected_path(trace_path.filepath, config))
-    return;
+  if (rejected_path(trace_path.filepath, config)) return;
 
   rs_tracepoint_t trace = extract_full_tracevals(trace_arg, &trace_path);
-  if (!strcmp("Rotoscope", StringValueCStr(trace.entity)))
-    return;
+  if (!strcmp("Rotoscope", StringValueCStr(trace.entity))) return;
 
-  if (config->flatten_output)
-  {
+  if (config->flatten_output) {
     rb_event_flag_t event_flag = rb_tracearg_event_flag(trace_arg);
     log_stack_frame(config->log, &config->stack, trace, event_flag);
-  }
-  else
-  {
+  } else {
     log_raw_trace(config->log, trace);
   }
 }
 
-static void close_log_handle(Rotoscope *config)
-{
-  if (config->log)
-  {
+static void close_log_handle(Rotoscope *config) {
+  if (config->log) {
     // Stop tracing so the event hook isn't called with a NULL log
-    if (config->state == RS_TRACING)
-    {
-      // During process cleanup, event hooks are removed and tracepoint may have already have
-      // been GCed, so we need a sanity check before disabling the tracepoint.
-      if (RB_TYPE_P(config->tracepoint, T_DATA) && CLASS_OF(config->tracepoint) == cTracePoint) {
+    if (config->state == RS_TRACING) {
+      // During process cleanup, event hooks are removed and tracepoint may have
+      // already have been GCed, so we need a sanity check before disabling the
+      // tracepoint.
+      if (RB_TYPE_P(config->tracepoint, T_DATA) &&
+          CLASS_OF(config->tracepoint) == cTracePoint) {
         rb_tracepoint_disable(config->tracepoint);
       }
     }
 
-    if (in_fork(config))
-    {
+    if (in_fork(config)) {
       close(fileno(config->log));
-    }
-    else
-    {
+    } else {
       fclose(config->log);
     }
     config->log = NULL;
   }
 }
 
-static void rs_gc_mark(Rotoscope *config)
-{
+static void rs_gc_mark(Rotoscope *config) {
   rb_gc_mark(config->log_path);
   rb_gc_mark(config->tracepoint);
   rs_stack_mark(&config->stack);
 }
 
-void rs_dealloc(Rotoscope *config)
-{
+void rs_dealloc(Rotoscope *config) {
   close_log_handle(config);
   rs_stack_free(&config->stack);
   xfree(config->blacklist);
   xfree(config);
 }
 
-static VALUE rs_alloc(VALUE klass)
-{
+static VALUE rs_alloc(VALUE klass) {
   Rotoscope *config;
-  VALUE self = Data_Make_Struct(klass, Rotoscope, rs_gc_mark, rs_dealloc, config);
+  VALUE self =
+      Data_Make_Struct(klass, Rotoscope, rs_gc_mark, rs_dealloc, config);
   config->log_path = Qnil;
-  config->tracepoint = rb_tracepoint_new(Qnil, EVENT_CALL | EVENT_RETURN, event_hook, (void *)config);
+  config->tracepoint = rb_tracepoint_new(Qnil, EVENT_CALL | EVENT_RETURN,
+                                         event_hook, (void *)config);
   config->pid = getpid();
   return self;
 }
 
-static Rotoscope *get_config(VALUE self)
-{
+static Rotoscope *get_config(VALUE self) {
   Rotoscope *config;
   Data_Get_Struct(self, Rotoscope, config);
   return config;
@@ -295,7 +246,8 @@ static Rotoscope *get_config(VALUE self)
 void copy_blacklist(Rotoscope *config, VALUE blacklist) {
   Check_Type(blacklist, T_ARRAY);
 
-  size_t blacklist_malloc_size = RARRAY_LEN(blacklist) * sizeof(*config->blacklist);
+  size_t blacklist_malloc_size =
+      RARRAY_LEN(blacklist) * sizeof(*config->blacklist);
 
   for (long i = 0; i < RARRAY_LEN(blacklist); i++) {
     VALUE ruby_string = RARRAY_AREF(blacklist, i);
@@ -318,8 +270,7 @@ void copy_blacklist(Rotoscope *config, VALUE blacklist) {
   }
 }
 
-VALUE initialize(int argc, VALUE *argv, VALUE self)
-{
+VALUE initialize(int argc, VALUE *argv, VALUE self) {
   Rotoscope *config = get_config(self);
   VALUE output_path, blacklist, flatten;
 
@@ -334,9 +285,9 @@ VALUE initialize(int argc, VALUE *argv, VALUE self)
   config->log_path = output_path;
   config->log = fopen(StringValueCStr(config->log_path), "w");
 
-  if (config->log == NULL)
-  {
-    fprintf(stderr, "\nERROR: Failed to open file handle at %s (%s)\n", StringValueCStr(config->log_path), strerror(errno));
+  if (config->log == NULL) {
+    fprintf(stderr, "\nERROR: Failed to open file handle at %s (%s)\n",
+            StringValueCStr(config->log_path), strerror(errno));
     exit(1);
   }
 
@@ -350,19 +301,16 @@ VALUE initialize(int argc, VALUE *argv, VALUE self)
   return self;
 }
 
-VALUE rotoscope_start_trace(VALUE self)
-{
+VALUE rotoscope_start_trace(VALUE self) {
   Rotoscope *config = get_config(self);
   rb_tracepoint_enable(config->tracepoint);
   config->state = RS_TRACING;
   return Qnil;
 }
 
-VALUE rotoscope_stop_trace(VALUE self)
-{
+VALUE rotoscope_stop_trace(VALUE self) {
   Rotoscope *config = get_config(self);
-  if (rb_tracepoint_enabled_p(config->tracepoint))
-  {
+  if (rb_tracepoint_enabled_p(config->tracepoint)) {
     rb_tracepoint_disable(config->tracepoint);
     config->state = RS_OPEN;
   }
@@ -370,28 +318,23 @@ VALUE rotoscope_stop_trace(VALUE self)
   return Qnil;
 }
 
-VALUE rotoscope_log_path(VALUE self)
-{
+VALUE rotoscope_log_path(VALUE self) {
   Rotoscope *config = get_config(self);
   return config->log_path;
 }
 
-VALUE rotoscope_mark(VALUE self)
-{
+VALUE rotoscope_mark(VALUE self) {
   Rotoscope *config = get_config(self);
-  if (config->log != NULL && !in_fork(config))
-  {
+  if (config->log != NULL && !in_fork(config)) {
     rs_stack_reset(&config->stack, STACK_CAPACITY);
     fprintf(config->log, "---\n");
   }
   return Qnil;
 }
 
-VALUE rotoscope_close(VALUE self)
-{
+VALUE rotoscope_close(VALUE self) {
   Rotoscope *config = get_config(self);
-  if (config->state == RS_CLOSED)
-  {
+  if (config->state == RS_CLOSED) {
     return Qtrue;
   }
   close_log_handle(config);
@@ -399,17 +342,14 @@ VALUE rotoscope_close(VALUE self)
   return Qtrue;
 }
 
-VALUE rotoscope_trace(VALUE self)
-{
+VALUE rotoscope_trace(VALUE self) {
   rotoscope_start_trace(self);
   return rb_ensure(rb_yield, Qundef, rotoscope_stop_trace, self);
 }
 
-VALUE rotoscope_state(VALUE self)
-{
+VALUE rotoscope_state(VALUE self) {
   Rotoscope *config = get_config(self);
-  switch (config->state)
-  {
+  switch (config->state) {
     case RS_OPEN:
       return ID2SYM(rb_intern("open"));
     case RS_TRACING:
@@ -419,8 +359,7 @@ VALUE rotoscope_state(VALUE self)
   }
 }
 
-void Init_rotoscope(void)
-{
+void Init_rotoscope(void) {
   cTracePoint = rb_const_get(rb_cObject, rb_intern("TracePoint"));
 
   cRotoscope = rb_define_class("Rotoscope", rb_cObject);
@@ -429,9 +368,12 @@ void Init_rotoscope(void)
   rb_define_method(cRotoscope, "trace", (VALUE(*)(ANYARGS))rotoscope_trace, 0);
   rb_define_method(cRotoscope, "mark", (VALUE(*)(ANYARGS))rotoscope_mark, 0);
   rb_define_method(cRotoscope, "close", (VALUE(*)(ANYARGS))rotoscope_close, 0);
-  rb_define_method(cRotoscope, "start_trace", (VALUE(*)(ANYARGS))rotoscope_start_trace, 0);
-  rb_define_method(cRotoscope, "stop_trace", (VALUE(*)(ANYARGS))rotoscope_stop_trace, 0);
-  rb_define_method(cRotoscope, "log_path", (VALUE(*)(ANYARGS))rotoscope_log_path, 0);
+  rb_define_method(cRotoscope, "start_trace",
+                   (VALUE(*)(ANYARGS))rotoscope_start_trace, 0);
+  rb_define_method(cRotoscope, "stop_trace",
+                   (VALUE(*)(ANYARGS))rotoscope_stop_trace, 0);
+  rb_define_method(cRotoscope, "log_path",
+                   (VALUE(*)(ANYARGS))rotoscope_log_path, 0);
   rb_define_method(cRotoscope, "state", (VALUE(*)(ANYARGS))rotoscope_state, 0);
 
   init_callsite();

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -14,24 +14,25 @@
 
 #define _RS_SHARED_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
 #define _RS_SHARED_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
-#define _RS_SHARED_CSV_VALUES(trace) \
-    StringValueCStr(trace.entity), \
-    StringValueCStr(trace.method_name), \
-    trace.method_level, \
-    StringValueCStr(trace.filepath), \
-    trace.lineno
+#define _RS_SHARED_CSV_VALUES(trace)                                 \
+  StringValueCStr(trace.entity), StringValueCStr(trace.method_name), \
+      trace.method_level, StringValueCStr(trace.filepath), trace.lineno
 
 #define RS_CSV_HEADER "event," _RS_SHARED_CSV_HEADER
+
 #define RS_CSV_FORMAT "%s," _RS_SHARED_CSV_FORMAT
 #define RS_CSV_VALUES(trace) trace.event, _RS_SHARED_CSV_VALUES(trace)
 
-#define RS_FLATTENED_CSV_HEADER _RS_SHARED_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
+#define RS_FLATTENED_CSV_HEADER                      \
+  _RS_SHARED_CSV_HEADER                              \
+  ",caller_entity,caller_method_name,caller_method_" \
+  "level"
 #define RS_FLATTENED_CSV_FORMAT _RS_SHARED_CSV_FORMAT ",\"%s\",\"%s\",%s"
-#define RS_FLATTENED_CSV_VALUES(frame) \
-    _RS_SHARED_CSV_VALUES(frame.tp), \
-    StringValueCStr(frame.caller->tp.entity), \
-    StringValueCStr(frame.caller->tp.method_name), \
-    frame.caller->tp.method_level
+#define RS_FLATTENED_CSV_VALUES(frame)               \
+  _RS_SHARED_CSV_VALUES(frame.tp)                    \
+  , StringValueCStr(frame.caller->tp.entity),        \
+      StringValueCStr(frame.caller->tp.method_name), \
+      frame.caller->tp.method_level
 
 typedef enum {
   RS_CLOSED = 0,
@@ -39,8 +40,7 @@ typedef enum {
   RS_TRACING,
 } rs_state;
 
-typedef struct
-{
+typedef struct {
   FILE *log;
   VALUE log_path;
   VALUE tracepoint;
@@ -52,8 +52,7 @@ typedef struct
   rs_stack_t stack;
 } Rotoscope;
 
-typedef struct
-{
+typedef struct {
   VALUE name;
   const char *method_level;
 } rs_class_desc_t;

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -1,63 +1,52 @@
+#include "stack.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "ruby.h"
-#include "stack.h"
 #include "tracepoint.h"
 
-static void insert_root_node(rs_stack_t *stack)
-{
+static void insert_root_node(rs_stack_t *stack) {
   VALUE rb_unknown_str = rb_str_new_cstr(UNKNOWN_STR);
-  rs_tracepoint_t root_trace = (rs_tracepoint_t) {
-    .event = UNKNOWN_STR,
-    .entity = rb_str_new_cstr("<ROOT>"),
-    .filepath = rb_unknown_str,
-    .method_name = rb_unknown_str,
-    .method_level = UNKNOWN_STR,
-    .lineno = 0
-  };
+  rs_tracepoint_t root_trace =
+      (rs_tracepoint_t){.event = UNKNOWN_STR,
+                        .entity = rb_str_new_cstr("<ROOT>"),
+                        .filepath = rb_unknown_str,
+                        .method_name = rb_unknown_str,
+                        .method_level = UNKNOWN_STR,
+                        .lineno = 0};
   rs_stack_push(stack, root_trace);
 }
 
-static void resize_buffer(rs_stack_t *stack)
-{
+static void resize_buffer(rs_stack_t *stack) {
   unsigned int newsize = stack->capacity * 2;
-  rs_stack_frame_t *resized_contents = REALLOC_N(stack->contents, rs_stack_frame_t, newsize);
+  rs_stack_frame_t *resized_contents =
+      REALLOC_N(stack->contents, rs_stack_frame_t, newsize);
   stack->contents = resized_contents;
   stack->capacity = newsize;
 }
 
-bool rs_stack_full(rs_stack_t *stack)
-{
+bool rs_stack_full(rs_stack_t *stack) {
   return stack->top >= stack->capacity - 1;
 }
 
-bool rs_stack_empty(rs_stack_t *stack)
-{
-  return stack->top < 0;
-}
+bool rs_stack_empty(rs_stack_t *stack) { return stack->top < 0; }
 
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace)
-{
-  if (rs_stack_full(stack))
-  {
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace) {
+  if (rs_stack_full(stack)) {
     resize_buffer(stack);
   }
 
-  rs_stack_frame_t *caller = rs_stack_empty(stack) ? NULL : rs_stack_peek(stack);
-  rs_stack_frame_t new_frame = (rs_stack_frame_t){
-    .tp = trace,
-    .caller = caller
-  };
+  rs_stack_frame_t *caller =
+      rs_stack_empty(stack) ? NULL : rs_stack_peek(stack);
+  rs_stack_frame_t new_frame =
+      (rs_stack_frame_t){.tp = trace, .caller = caller};
 
   stack->contents[++stack->top] = new_frame;
   return new_frame;
 }
 
-rs_stack_frame_t rs_stack_pop(rs_stack_t *stack)
-{
-  if (rs_stack_empty(stack))
-  {
+rs_stack_frame_t rs_stack_pop(rs_stack_t *stack) {
+  if (rs_stack_empty(stack)) {
     fprintf(stderr, "Stack is empty!\n");
     exit(1);
   }
@@ -65,10 +54,8 @@ rs_stack_frame_t rs_stack_pop(rs_stack_t *stack)
   return stack->contents[stack->top--];
 }
 
-rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack)
-{
-  if (rs_stack_empty(stack))
-  {
+rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack) {
+  if (rs_stack_empty(stack)) {
     fprintf(stderr, "Stack is empty!\n");
     exit(1);
   }
@@ -76,22 +63,19 @@ rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack)
   return &stack->contents[stack->top];
 }
 
-void rs_stack_reset(rs_stack_t *stack, unsigned int capacity)
-{
+void rs_stack_reset(rs_stack_t *stack, unsigned int capacity) {
   stack->top = -1;
   insert_root_node(stack);
 }
 
-void rs_stack_free(rs_stack_t *stack)
-{
+void rs_stack_free(rs_stack_t *stack) {
   xfree(stack->contents);
   stack->contents = NULL;
   stack->top = -1;
   stack->capacity = 0;
 }
 
-void rs_stack_init(rs_stack_t *stack, unsigned int capacity)
-{
+void rs_stack_init(rs_stack_t *stack, unsigned int capacity) {
   rs_stack_frame_t *contents = ALLOC_N(rs_stack_frame_t, capacity);
   stack->contents = contents;
   stack->capacity = capacity;
@@ -100,10 +84,8 @@ void rs_stack_init(rs_stack_t *stack, unsigned int capacity)
   insert_root_node(stack);
 }
 
-void rs_stack_mark(rs_stack_t *stack)
-{
-  for (int i=0; i<=stack->top; i++)
-  {
+void rs_stack_mark(rs_stack_t *stack) {
+  for (int i = 0; i <= stack->top; i++) {
     rs_stack_frame_t frame = stack->contents[i];
     rs_tracepoint_mark(&frame.tp);
   }

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -5,14 +5,12 @@
 
 #define UNKNOWN_STR "<UNKNOWN>"
 
-typedef struct rs_stack_frame_t
-{
+typedef struct rs_stack_frame_t {
   struct rs_tracepoint_t tp;
   struct rs_stack_frame_t *caller;
 } rs_stack_frame_t;
 
-typedef struct
-{
+typedef struct {
   int capacity;
   int top;
   rs_stack_frame_t *contents;

--- a/ext/rotoscope/tracepoint.c
+++ b/ext/rotoscope/tracepoint.c
@@ -1,8 +1,7 @@
-#include "ruby.h"
 #include "tracepoint.h"
+#include "ruby.h"
 
-void rs_tracepoint_mark(rs_tracepoint_t *tracepoint)
-{
+void rs_tracepoint_mark(rs_tracepoint_t *tracepoint) {
   rb_gc_mark(tracepoint->entity);
   rb_gc_mark(tracepoint->filepath);
   rb_gc_mark(tracepoint->method_name);

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -1,8 +1,9 @@
 #ifndef _INC_ROTOSCOPE_TRACEPOINT_H_
 #define _INC_ROTOSCOPE_TRACEPOINT_H_
 
-typedef struct rs_tracepoint_t
-{
+#include "ruby.h"
+
+typedef struct rs_tracepoint_t {
   const char *event;
   VALUE entity;
   VALUE filepath;


### PR DESCRIPTION
Assuming `clang-format` is installed, `bin/fmt` will format the C files in the repo to match Google's recommended formatting.

Aside from the formatting, this introduces the `bin/fmt` script and the `dev fmt` command (which executes the aformentioned script). No other changes.