### PR TITLE
Specify _POSIX_SOURCE in compiler for POSIX compliance

### DIFF
--- a/ext/rotoscope/extconf.rb
+++ b/ext/rotoscope/extconf.rb
@@ -2,4 +2,6 @@
 require "mkmf"
 
 $CFLAGS << ' -std=c99 -Wall -Werror -Wno-declaration-after-statement'
+$defs << "-D_POSIX_SOURCE"
+
 create_makefile('rotoscope/rotoscope')


### PR DESCRIPTION
Based on [this reference](https://community.spiceworks.com/linux/man/3/fileno) that states:

> The function fileno() conforms to POSIX.1-2001 and POSIX.1-2008. 

and [this stackoverflow answer](https://stackoverflow.com/a/5724485) that says:

>   500 - X/Open 5, incorporating POSIX 1995
>   600 - X/Open 6, incorporating POSIX 2004
>   700 - X/Open 7, incorporating POSIX 2008

and also the [feature_test_macros man page]() that says:

> (Since glibc 2.3.3) The value 200112L or greater additionally exposes definitions corresponding to the POSIX.1-2001 base specification (excluding the XSI extension).

…I'm specifying `-D_X_OPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112L` to get X/Open 6 and POSIX 2001 compliance, of which `fileno` belongs. 

---

This change isn't required to make compilation work, but it's good practice when relying on non-UNIX-standard features. It also would have fixed https://github.com/Shopify/rotoscope/pull/31#issuecomment-311461584, so if this ships first I can remove the [comment that disables clang-format](https://github.com/Shopify/rotoscope/pull/31/files#diff-6be261c9e5098e0e672e58118a1dbd90R1) to make the codebase 100% compliant with that format.