### PR TITLE
Recursively call singleton2str when singleton of instance

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -60,20 +60,7 @@ static VALUE singleton2str(VALUE klass) {
     return name;
   } else  // singleton of an instance
   {
-    VALUE real_klass;
-    VALUE ancestors = rb_mod_ancestors(klass);
-    if (RARRAY_LEN(ancestors) > 0 &&
-        !NIL_P(real_klass = rb_ary_entry(ancestors, 1))) {
-      VALUE cached_lookup = rb_class_path_cached(real_klass);
-      if (RTEST(cached_lookup)) {
-        return cached_lookup;
-      } else {
-        return rb_class_name(real_klass);
-      }
-    }
-    // fallback in case we can't come up with a name
-    // based on the ancestors
-    return rb_any_to_s(klass);
+    return singleton2str(CLASS_OF(klass));
   }
 }
 

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -10,7 +10,13 @@ require 'csv'
 require 'fixture_inner'
 require 'fixture_outer'
 
+module PrependedModule
+  def prepended_method; end
+end
+
 class Example
+  prepend PrependedModule
+
   class << self
     def singleton_method
       true


### PR DESCRIPTION
By adding a `prepended` module, I was able to break [this existing test](https://github.com/Shopify/rotoscope/blob/a8bfc61a3695158064c071166de990ee500b184c/test/rotoscope_test.rb#L162-L176) for singletons of instances. Prior to this change, we were attempting to look up the name of the instance via its ancestors, but that breaks with `prepended` modules.

The old method produced inconsistent event entities, e.g. calling `Example.new.singleton_class` when `Example` has _any_ prepended object produces:

```
...
call Example#singleton_class
return PrependedModule#singleton_class
...
```
For the solution, if we call ourselves recursively with `CLASS_OF(klass)`, we're able to use the logic for class singletons successfully rather than any special case for singletons of instances.

- [x] `bin/fmt` was successfully run
