### PR TITLE
Don't log when outside of main thread

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -51,6 +51,7 @@ typedef struct {
   unsigned long blacklist_size;
   bool flatten_output;
   pid_t pid;
+  unsigned long tid;
   rs_state state;
   rs_stack_t stack;
   rs_strmemo_t *call_memo;


### PR DESCRIPTION
Closes #22

Ignore calls when `Thread.current.object_id` is different from when Rotoscope was started.

- [x] `bin/fmt` was successfully run
