### PR TITLE
Maintain consistent identifier when dealing with Class.new

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -103,9 +103,12 @@ static rs_class_desc_t tracearg_class(rb_trace_arg_t *trace_arg) {
   VALUE klass;
   VALUE self = rb_tracearg_self(trace_arg);
 
-  if (RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_OBJECT) ||
-      RB_TYPE_P(self, T_CLASS)) {
-    klass = RBASIC_CLASS(self);
+  if (RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_OBJECT)) {
+    klass = CLASS_OF(self);
+  } else if (RB_TYPE_P(self, T_CLASS)) {
+    // Does the object have an attached singleton?
+    // If not, name based on self instead of its singleton
+    klass = (FL_TEST(CLASS_OF(self), FL_SINGLETON)) ? CLASS_OF(self) : self;
   } else {
     klass = rb_tracearg_defined_class(trace_arg);
   }

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -390,6 +390,19 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
+  def test_dynamic_class_creation
+    contents = rotoscope_trace { Class.new }
+
+    assert_equal [
+      { event: "call", entity: "Class", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "#<Class:0xXXXXXX>", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "Object", method_name: "inherited", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Object", method_name: "inherited", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "#<Class:0xXXXXXX>", method_name: "initialize", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Class", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 }
+    ], parse_and_normalize(contents)
+  end
+
   private
 
   def parse_and_normalize(csv_string)
@@ -397,6 +410,7 @@ class RotoscopeTest < MiniTest::Test
       row = row.to_h
       row[:lineno] = -1
       row[:filepath] = row[:filepath].gsub(ROOT_FIXTURE_PATH, '')
+      row[:entity] = row[:entity].gsub(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX")
       row
     end
   end


### PR DESCRIPTION
Prior to this change, we would see a trace of `Class.new` look like:

```
-> Class.new
  ->  Class#initialize
    -> Object.inherited
    <- Object.inherited
  <- #<Class:0x007fe1681f3b90>.initialize
<- Class.new
```

…where the caller of `#initialize` is not the same name as the returner. This boils down to how MRI handles class initialization along with how Rotoscope attempts to infer object names. At the beginning of `Class.new`, we have no singleton class attached to the object, which is what Rotoscope uses to infer the name. By the end of the process, we are about to read the singleton class and pull out the identifier.

By checking first if `CLASS_OF(self)` returns a singleton (as most situations would, _except_ in this case), we can decide to match the name directly based on `self` instead:

```c
klass = (FL_TEST(CLASS_OF(self), FL_SINGLETON)) ? CLASS_OF(self) : self;
return class2str(klass);
```

- [x] `bin/fmt` was successfully run
