### PR TITLE
Add failing test for define_singleton_method

### DIFF
--- a/test/monadify.rb
+++ b/test/monadify.rb
@@ -1,0 +1,16 @@
+module Monadify
+  define_method("contents") do
+    42
+  end
+
+  def foo
+    false
+  end
+
+  def monad(value)
+    foo
+    contents
+    define_singleton_method("contents=") { |val| val }
+    self.contents = value
+  end
+end


### PR DESCRIPTION
It turns out when using dynamically defining methods via `define_method` and `define_singleton_method`, the call stack is inconsistent compared with how pre-defined Ruby methods look.

---

On `:call` events, the frame points to where the method is received in Ruby, i.e. the block passed to `define_method` or `define_singleton_method`. This is the [expected behaviour](https://github.com/Shopify/rotoscope/issues/16) for Ruby invocations:

> [TracePoint] has the unfortunate side effect of pointing to the callee of the method (i.e. where the method is received), rather than the caller.

_But_, when the `:return` event fires, instead of pointing to the end of the method definition like a normal ruby method, it points one frame up the stack, to where the original `caller` occurred. Since we assume Ruby methods point one level deeper, Rotoscope pops the frame one level further, and points to where the caller's caller came from. This means the `call` and `return` events won't match up.

---

I tried to figure out how to get around this one (by using Ruby's bitmasks to determine if it was a dynamically defined method, etc.), but I've been unsuccessful thus far. As a compromise, I've added a failing test case with a `skip`, just to be able to replicate the problem.

This problem is currently avoidable via `flatten: true`, since [unmatched returns are ignored](https://github.com/Shopify/rotoscope/blob/929d7e27c87c740a864f857741272cadce584513/ext/rotoscope/rotoscope.c#L161).

- [x] `bin/fmt` was successfully run
