### PR TITLE
Add string arg option for Rotoscope#mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ IO,write,instance,example/flattened_dog.rb,11,IO,puts,instance
   - [`trace`](#rotoscopetraceblock)
   - [`start_trace`](#rotoscopestart_trace)
   - [`stop_trace`](#rotoscopestop_trace)
-  - [`flatten`](#rotoscopeflattendest)
-  - [`mark`](#rotoscopemark)
+  - [`mark`](#rotoscopemarkstr--)
   - [`close`](#rotoscopeclose)
   - [`state`](#rotoscopestate)
   - [`closed?`](#rotoscopeclosed)
@@ -156,15 +155,15 @@ rs.start_trace
 rs.stop_trace
 ```
 
-#### `Rotoscope#mark`
+#### `Rotoscope#mark(str = "")`
 
- Inserts a marker '---' to divide output. Useful for segmenting multiple blocks of code that are being profiled.
+ Inserts a marker '--- ' to divide output. Useful for segmenting multiple blocks of code that are being profiled. If `str` is provided, the line will be prefixed by '--- ', followed by the string passed.
 
 ```ruby
 rs = Rotoscope.new(dest)
 rs.start_trace
 # code to trace...
-rs.mark
+rs.mark('Something goes wrong here') # produces `--- Something goes wrong here` in the output
 # more code ...
 rs.stop_trace
 ```

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -327,12 +327,18 @@ VALUE rotoscope_log_path(VALUE self) {
   return config->log_path;
 }
 
-VALUE rotoscope_mark(VALUE self) {
+VALUE rotoscope_mark(int argc, VALUE *argv, VALUE self) {
+  VALUE str;
+  rb_scan_args(argc, argv, "01", &str);
+
+  if (NIL_P(str)) str = rb_str_new2("");
+  Check_Type(str, T_STRING);
+
   Rotoscope *config = get_config(self);
   if (config->log != NULL && !in_fork(config)) {
     rs_stack_reset(&config->stack, STACK_CAPACITY);
     rs_strmemo_free(config->call_memo);
-    fprintf(config->log, "---\n");
+    fprintf(config->log, "--- %s\n", StringValueCStr(str));
   }
   return Qnil;
 }
@@ -371,7 +377,7 @@ void Init_rotoscope(void) {
   rb_define_alloc_func(cRotoscope, rs_alloc);
   rb_define_method(cRotoscope, "initialize", initialize, -1);
   rb_define_method(cRotoscope, "trace", (VALUE(*)(ANYARGS))rotoscope_trace, 0);
-  rb_define_method(cRotoscope, "mark", (VALUE(*)(ANYARGS))rotoscope_mark, 0);
+  rb_define_method(cRotoscope, "mark", (VALUE(*)(ANYARGS))rotoscope_mark, -1);
   rb_define_method(cRotoscope, "close", (VALUE(*)(ANYARGS))rotoscope_close, 0);
   rb_define_method(cRotoscope, "start_trace",
                    (VALUE(*)(ANYARGS))rotoscope_start_trace, 0);

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -104,7 +104,21 @@ class RotoscopeTest < MiniTest::Test
       rs.mark
     end
 
-    assert_includes contents.split("\n"), '---'
+    assert_includes contents.split("\n"), '--- '
+  end
+
+  def test_mark_with_custom_strings
+    mark_strings = ["Hello", "ÅÉÎØÜ åéîøü"]
+    contents = rotoscope_trace do |rs|
+      e = Example.new
+      e.normal_method
+      mark_strings.each { |str| rs.mark(str) }
+    end
+
+    content_lines = contents.split("\n")
+    mark_strings.each do |str|
+      assert_includes content_lines, "--- #{str}"
+    end
   end
 
   def test_flatten


### PR DESCRIPTION
In order to produce more detailed context in the output, this PR allows users to pass in a string to `Rotoscope#mark` in order to insert custom values into the CSV. I suggested this as a potential solution for @mcgain as mentioned in https://github.com/Shopify/testability/issues/102 (private repo) to help keep track of the test context.

- [x] `bin/fmt` was successfully run
