### PR TITLE
Fix test exit status

### DIFF
--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -479,4 +479,4 @@ end
 
 # https://github.com/seattlerb/minitest/pull/683 needed to use
 # autorun without affecting the exit status of forked processes
-Minitest.run(ARGV)
+exit Minitest.run(ARGV)


### PR DESCRIPTION
## Problem

https://github.com/Shopify/rotoscope/pull/41 had a test failure, but CI was green.  I noticed that the exit status was `0` when running locally, which I think is why CI was green despite the failing test.  The reason why it wasn't exiting with a failure was that 
#25 manually runs the tests, but wasn't using the result of `Minitest.run` but wasn't passing the return value to `exit` as [`Minitest.autorun`](https://github.com/seattlerb/minitest/blob/ca6a71ca901016db09a5ad466b4adea4b52a504a/lib/minitest.rb#L56-L63) does.

## Solution

Call `exit` with the return value of `Minitest.run`