### PR TITLE
Detect and ignore block returns

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -7,11 +7,16 @@
 
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)
 #define EVENT_RETURN (RUBY_EVENT_RETURN | RUBY_EVENT_C_RETURN)
+#define METHOD_CALL_P(event) event &EVENT_CALL
+#define METHOD_RETURN_P(event) event &EVENT_RETURN
 
 #define CLASS_METHOD "class"
 #define INSTANCE_METHOD "instance"
 
+#define VM_BLOCK_PREFIX "block "
+
 #define STACK_CAPACITY 500
+#define LOG_BUFFER_SIZE 1000
 
 // clang-format off
 #define _RS_COMMON_CSV_HEADER "entity,method_name,method_level,filepath,lineno"

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -1,5 +1,6 @@
 #ifndef _INC_ROTOSCOPE_STACK_H_
 #define _INC_ROTOSCOPE_STACK_H_
+
 #include <stdbool.h>
 #include "tracepoint.h"
 

--- a/ext/rotoscope/tracepoint.c
+++ b/ext/rotoscope/tracepoint.c
@@ -1,9 +1,26 @@
 #include "tracepoint.h"
 #include "ruby.h"
 
+rs_raw_tracepoint_t rs_raw_from_tracepoint(VALUE tracepoint) {
+  rb_trace_arg_t *trace_arg = rb_tracearg_from_tracepoint(tracepoint);
+  return (rs_raw_tracepoint_t){
+      .self = rb_tracearg_self(trace_arg),
+      .method_id = rb_tracearg_method_id(trace_arg),
+  };
+}
+
+void rs_raw_tracepoint_mark(rs_raw_tracepoint_t *tracepoint) {
+  rb_gc_mark(tracepoint->method_id);
+  rb_gc_mark(tracepoint->self);
+}
+
 void rs_tracepoint_mark(rs_tracepoint_t *tracepoint) {
   rb_gc_mark(tracepoint->entity);
   rb_gc_mark(tracepoint->filepath);
   rb_gc_mark(tracepoint->method_name);
-  rb_gc_mark(tracepoint->raw);
+  rs_raw_tracepoint_mark(&tracepoint->raw);
+}
+
+bool rs_raw_tracepoint_cmp(rs_raw_tracepoint_t *tp1, rs_raw_tracepoint_t *tp2) {
+  return (tp1->method_id == tp2->method_id) && (tp1->self == tp2->self);
 }

--- a/ext/rotoscope/tracepoint.c
+++ b/ext/rotoscope/tracepoint.c
@@ -5,4 +5,5 @@ void rs_tracepoint_mark(rs_tracepoint_t *tracepoint) {
   rb_gc_mark(tracepoint->entity);
   rb_gc_mark(tracepoint->filepath);
   rb_gc_mark(tracepoint->method_name);
+  rb_gc_mark(tracepoint->raw);
 }

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -11,7 +11,7 @@ typedef struct rs_tracepoint_t {
   VALUE method_name;
   const char *method_level;
   unsigned int lineno;
-  rb_trace_arg_t *raw;
+  VALUE raw;
 } rs_tracepoint_t;
 
 void rs_tracepoint_mark(rs_tracepoint_t *tracepoint);

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -3,6 +3,16 @@
 
 #include <ruby.h>
 #include <ruby/debug.h>
+#include <stdbool.h>
+
+typedef struct rs_raw_tracepoint_t {
+  VALUE method_id;
+  VALUE self;
+} rs_raw_tracepoint_t;
+
+rs_raw_tracepoint_t rs_raw_from_tracepoint(VALUE tracepoint);
+void rs_raw_tracepoint_mark(rs_raw_tracepoint_t *tracepoint);
+bool rs_raw_tracepoint_cmp(rs_raw_tracepoint_t *tp1, rs_raw_tracepoint_t *tp2);
 
 typedef struct rs_tracepoint_t {
   const char *event;
@@ -11,7 +21,7 @@ typedef struct rs_tracepoint_t {
   VALUE method_name;
   const char *method_level;
   unsigned int lineno;
-  VALUE raw;
+  rs_raw_tracepoint_t raw;
 } rs_tracepoint_t;
 
 void rs_tracepoint_mark(rs_tracepoint_t *tracepoint);

--- a/ext/rotoscope/tracepoint.h
+++ b/ext/rotoscope/tracepoint.h
@@ -1,7 +1,8 @@
 #ifndef _INC_ROTOSCOPE_TRACEPOINT_H_
 #define _INC_ROTOSCOPE_TRACEPOINT_H_
 
-#include "ruby.h"
+#include <ruby.h>
+#include <ruby/debug.h>
 
 typedef struct rs_tracepoint_t {
   const char *event;
@@ -10,6 +11,7 @@ typedef struct rs_tracepoint_t {
   VALUE method_name;
   const char *method_level;
   unsigned int lineno;
+  rb_trace_arg_t *raw;
 } rs_tracepoint_t;
 
 void rs_tracepoint_mark(rs_tracepoint_t *tracepoint);

--- a/test/monadify.rb
+++ b/test/monadify.rb
@@ -1,16 +1,14 @@
 module Monadify
+  def self.extended(base)
+    base.define_singleton_method("contents=") { |val| val }
+  end
+
   define_method("contents") do
     42
   end
 
-  def foo
-    false
-  end
-
   def monad(value)
-    foo
     contents
-    define_singleton_method("contents=") { |val| val }
     self.contents = value
   end
 end

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -424,13 +424,22 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
-  def test_dynamic_methods_in_blacklist
-    skip <<-FAILING_TEST_CASE
-      Return events for dynamically created methods (define_method, define_singleton_method)
-      do not have the correct stack frame information (the call of a dynamically defined method
-      is correctly treated as a Ruby :call, but its return must be treated as a :c_return)
-    FAILING_TEST_CASE
+  def test_block_defined_methods
+    contents = rotoscope_trace { Example.apply("my value!") }
 
+    assert_equal [
+      { event: "call", entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "Example", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "return", entity: "Example", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "call", entity: "Example", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "return", entity: "Example", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "return", entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+    ], parse_and_normalize(contents)
+  end
+
+  def test_block_defined_methods_in_blacklist
     contents = rotoscope_trace(blacklist: [MONADIFY_PATH]) { Example.apply("my value!") }
 
     assert_equal [
@@ -441,8 +450,7 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
-  def test_flatten_with_dynamic_methods_in_blacklist
-    # the failing test above passes when using `flatten: true` since unmatched stack returns are ignored
+  def test_flatten_with_block_defined_methods_in_blacklist
     contents = rotoscope_trace(blacklist: [MONADIFY_PATH], flatten: true) { Example.apply("my value!") }
 
     assert_equal [

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -459,6 +459,15 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
+  def test_flatten_with_invoking_block_defined_methods
+    contents = rotoscope_trace(blacklist: [MONADIFY_PATH], flatten: false) { Example.contents }
+
+    assert_equal [
+      { event: "call", entity: "Example", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Example", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+    ], parse_and_normalize(contents)
+  end
+
   def test_module_extend
     contents = rotoscope_trace { Module.new { extend(MyModule) } }
 


### PR DESCRIPTION
Fixes #39 

_The diff is a bit confusing but the tl;dr is that the logic behind the flattened and unflattened csv logging is more unified now, other than the string formatting._

### Problem

When using block-defined methods (e.g. via define_method or define_singleton_method), the call stack is inconsistent compared with how predefined Ruby methods look.

Thanks to [Dylan's efforts](https://github.com/Shopify/rotoscope/issues/39#issuecomment-319147609), we know this is due to the block definition ending with a `leave` instruction _before_ the `RUBY_EVENT_RETURN` event hook is triggered, unlike regularly-defined methods that have the `leave` instruction _after_ the `RUBY_EVENT_RETURN` event hook.

### Solution

We now share the same stack-tracking method used by the `flatten` option to track expected returns based on the previous calls. If an `EVENT_RETURN` is received that does not have a matching `EVENT_CALL` prior to it, we check to see if it is a block return via the VM instruction sequence output. If so, we ignore the event and move on.

- [x] `bin/fmt` was successfully run
