### PR TITLE
Fix entity and method_level for module extend

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -66,16 +66,19 @@ static VALUE singleton2str(VALUE klass) {
   }
 }
 
-static VALUE class2str(VALUE klass) {
-  VALUE cached_lookup = rb_class_path_cached(klass);
-
-  if (!NIL_P(cached_lookup)) {
-    return cached_lookup;
+static VALUE class_path(VALUE klass) {
+  VALUE cached_path = rb_class_path_cached(klass);
+  if (!NIL_P(cached_path)) {
+    return cached_path;
   }
+  return rb_class_path(klass);
+}
+
+static VALUE class2str(VALUE klass) {
   if (FL_TEST(klass, FL_SINGLETON)) {
     return singleton2str(klass);
   } else {
-    return rb_class_path(klass);
+    return class_path(klass);
   }
 }
 

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -14,9 +14,10 @@
 #include "tracepoint.h"
 
 VALUE cRotoscope, cTracePoint;
+ID id_initialize;
 
 // recursive with singleton2str
-static rs_class_desc_t class2str(VALUE klass);
+static VALUE class2str(VALUE klass);
 
 static unsigned long gettid() {
   return NUM2ULONG(rb_obj_id(rb_thread_current()));
@@ -58,35 +59,24 @@ static bool is_class_singleton(VALUE klass) {
 
 static VALUE singleton2str(VALUE klass) {
   if (is_class_singleton(klass)) {
-    VALUE obj = class_of_singleton(klass);
-    VALUE cached_lookup = rb_class_path_cached(obj);
-    VALUE name = (NIL_P(cached_lookup)) ? rb_class_name(obj) : cached_lookup;
-    return name;
+    return class2str(class_of_singleton(klass));
   } else  // singleton of an instance
   {
     return singleton2str(CLASS_OF(klass));
   }
 }
 
-static rs_class_desc_t class2str(VALUE klass) {
-  rs_class_desc_t real_class;
-  real_class.method_level = INSTANCE_METHOD;
-
+static VALUE class2str(VALUE klass) {
   VALUE cached_lookup = rb_class_path_cached(klass);
-  if (RTEST(cached_lookup)) {
-    real_class.name = cached_lookup;
-  } else {
-    if (FL_TEST(klass, FL_SINGLETON)) {
-      real_class.name = singleton2str(klass);
-      if (is_class_singleton(klass)) {
-        real_class.method_level = CLASS_METHOD;
-      }
-    } else {
-      real_class.name = rb_class_path(klass);
-    }
-  }
 
-  return real_class;
+  if (!NIL_P(cached_lookup)) {
+    return cached_lookup;
+  }
+  if (FL_TEST(klass, FL_SINGLETON)) {
+    return singleton2str(klass);
+  } else {
+    return rb_class_path(klass);
+  }
 }
 
 static rs_callsite_t tracearg_path(rb_trace_arg_t *trace_arg) {
@@ -101,19 +91,21 @@ static rs_callsite_t tracearg_path(rb_trace_arg_t *trace_arg) {
 
 static rs_class_desc_t tracearg_class(rb_trace_arg_t *trace_arg) {
   VALUE klass;
+  const char *method_level;
   VALUE self = rb_tracearg_self(trace_arg);
 
-  if (RB_TYPE_P(self, T_MODULE) || RB_TYPE_P(self, T_OBJECT)) {
-    klass = CLASS_OF(self);
-  } else if (RB_TYPE_P(self, T_CLASS)) {
-    // Does the object have an attached singleton?
-    // If not, name based on self instead of its singleton
-    klass = (FL_TEST(CLASS_OF(self), FL_SINGLETON)) ? CLASS_OF(self) : self;
+  if ((RB_TYPE_P(self, T_CLASS) || RB_TYPE_P(self, T_MODULE)) &&
+      SYM2ID(rb_tracearg_method_id(trace_arg)) != id_initialize) {
+    method_level = CLASS_METHOD;
+    klass = self;
   } else {
-    klass = rb_tracearg_defined_class(trace_arg);
+    method_level = INSTANCE_METHOD;
+    klass = rb_obj_class(self);
   }
 
-  return class2str(klass);
+  return (rs_class_desc_t){
+      .name = class2str(klass), .method_level = method_level,
+  };
 }
 
 static VALUE tracearg_method_name(rb_trace_arg_t *trace_arg) {
@@ -372,6 +364,8 @@ VALUE rotoscope_state(VALUE self) {
 
 void Init_rotoscope(void) {
   cTracePoint = rb_const_get(rb_cObject, rb_intern("TracePoint"));
+
+  id_initialize = rb_intern("initialize");
 
   cRotoscope = rb_define_class("Rotoscope", rb_cObject);
   rb_define_alloc_func(cRotoscope, rs_alloc);

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -142,8 +142,8 @@ class RotoscopeTest < MiniTest::Test
     assert_equal [
       { entity: "Example", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
       { entity: "Example", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Example", caller_method_name: "new", caller_method_level: "class" },
-      { entity: "Integer", method_name: "times", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
-      { entity: "Example", method_name: "normal_method", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Integer", caller_method_name: "times", caller_method_level: "instance" },
+      { entity: "Fixnum", method_name: "times", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
+      { entity: "Example", method_name: "normal_method", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Fixnum", caller_method_name: "times", caller_method_level: "instance" },
     ], parse_and_normalize(contents)
   end
 
@@ -416,10 +416,10 @@ class RotoscopeTest < MiniTest::Test
 
     assert_equal [
       { event: "call", entity: "Class", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "call", entity: "#<Class:0xXXXXXX>", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "Class", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "call", entity: "Object", method_name: "inherited", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "return", entity: "Object", method_name: "inherited", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "return", entity: "#<Class:0xXXXXXX>", method_name: "initialize", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Class", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "return", entity: "Class", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 }
     ], parse_and_normalize(contents)
   end
@@ -451,6 +451,56 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
+  def test_module_extend
+    contents = rotoscope_trace { Module.new { extend(MyModule) } }
+
+    assert_equal [
+      { event: "call", entity: "Module", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "Module", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "#<Module:0xXXXXXX>", method_name: "extend", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "MyModule", method_name: "extend_object", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "MyModule", method_name: "extend_object", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "MyModule", method_name: "extended", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "MyModule", method_name: "extended", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "#<Module:0xXXXXXX>", method_name: "extend", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Module", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Module", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+    ], parse_and_normalize(contents)
+  end
+
+  def test_module_extend_self
+    contents = rotoscope_trace { Module.new { extend self } }
+
+    assert_equal [
+      { event: "call", entity: "Module", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "Module", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "#<Module:0xXXXXXX>", method_name: "extend", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "#<Module:0xXXXXXX>", method_name: "extend_object", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "#<Module:0xXXXXXX>", method_name: "extend_object", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "#<Module:0xXXXXXX>", method_name: "extended", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "#<Module:0xXXXXXX>", method_name: "extended", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "#<Module:0xXXXXXX>", method_name: "extend", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Module", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Module", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+    ], parse_and_normalize(contents)
+  end
+
+  def test_flatten_module_extend
+    contents = rotoscope_trace(flatten: true) do
+      m = Module.new { extend(MyModule) }
+      m.module_method
+    end
+
+    assert_equal [
+      { entity: "Module", method_name: "new", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
+      { entity: "Module", method_name: "initialize", method_level: "instance", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Module", caller_method_name: "new", caller_method_level: "class" },
+      { entity: "#<Module:0xXXXXXX>", method_name: "extend", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Module", caller_method_name: "initialize", caller_method_level: "instance" },
+      { entity: "MyModule", method_name: "extend_object", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "#<Module:0xXXXXXX>", caller_method_name: "extend", caller_method_level: "class" },
+      { entity: "MyModule", method_name: "extended", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "#<Module:0xXXXXXX>", caller_method_name: "extend", caller_method_level: "class" },
+      { entity: "#<Module:0xXXXXXX>", method_name: "module_method", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
+    ], parse_and_normalize(contents)
+  end
+
   private
 
   def parse_and_normalize(csv_string)
@@ -459,6 +509,9 @@ class RotoscopeTest < MiniTest::Test
       row[:lineno] = -1
       row[:filepath] = row[:filepath].gsub(ROOT_FIXTURE_PATH, '')
       row[:entity] = row[:entity].gsub(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX")
+      if row.key?(:caller_entity)
+        row[:caller_entity] = row[:caller_entity].gsub(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX")
+      end
       row
     end
   end


### PR DESCRIPTION
## Problem

There were problems with determining entity and method level for module extends that #43 was trying to fix, but that fix still left inconsistencies.

Another problem I noticed was that sometimes the entity would be determined using the class the method was defined (i.e. rb_tracearg_defined_class) instead of the class of the object the method was called on (i.e. rb_tracearg_self). This is why the entity was showing up as Integer instead of Fixnum for the call `10.times`.

## Solution

Simplify the logic for determining the method level by doing that in tracearg_class so class2str just needs to return the class name.  If `self` is a class or module, then it is a class method call, otherwise it is an instance method call.  The exception to this rule is `initialize` for a class or module (e.g. from `Class.new` or `Module.new`).