### PR TITLE
Fix block method return filepath and lineno using call stack frame.

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -132,8 +132,8 @@ static void log_trace_event_with_caller(FILE *stream,
     caller = caller->caller;
   }
 
-  sprintf((char *)output_buffer, RS_FLATTENED_CSV_FORMAT "\n",
-          RS_FLATTENED_CSV_VALUES(&stack_frame->tp, &caller->tp));
+  snprintf((char *)output_buffer, LOG_BUFFER_SIZE, RS_FLATTENED_CSV_FORMAT "\n",
+           RS_FLATTENED_CSV_VALUES(&stack_frame->tp, &caller->tp));
 
   if (rs_strmemo_uniq(call_memo, output_buffer)) {
     fputs((char *)output_buffer, stream);

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -119,30 +119,24 @@ static rs_tracepoint_t extract_full_tracevals(rb_trace_arg_t *trace_arg,
 
 static bool in_fork(Rotoscope *config) { return config->pid != getpid(); }
 
-static bool tracecmp(rs_tracepoint_t *a, rs_tracepoint_t *b) {
-  return (!rb_str_cmp(a->method_name, b->method_name) &&
-          !rb_str_cmp(a->entity, b->entity) &&
-          a->method_level == b->method_level);
-}
-
-static void log_raw_trace(FILE *stream, rs_tracepoint_t trace) {
+static void log_trace_event(FILE *stream, rs_tracepoint_t *trace) {
   fprintf(stream, RS_CSV_FORMAT "\n", RS_CSV_VALUES(trace));
 }
 
-unsigned char output_buffer[500];
-static void log_stack_frame(FILE *stream, rs_stack_t *stack,
-                            rs_strmemo_t **call_memo, rs_tracepoint_t trace,
-                            rb_event_flag_t event) {
-  if (event & EVENT_CALL) {
-    rs_stack_frame_t frame = rs_stack_push(stack, trace);
-    sprintf((char *)output_buffer, RS_FLATTENED_CSV_FORMAT "\n",
-            RS_FLATTENED_CSV_VALUES(frame));
+unsigned char output_buffer[LOG_BUFFER_SIZE];
+static void log_trace_event_with_caller(FILE *stream,
+                                        rs_stack_frame_t *stack_frame,
+                                        rs_strmemo_t **call_memo) {
+  rs_stack_frame_t *caller = stack_frame->caller;
+  while (caller->blacklisted) {
+    caller = caller->caller;
+  }
 
-    if (rs_strmemo_uniq(call_memo, output_buffer)) {
-      fputs((char *)output_buffer, stream);
-    }
-  } else if (event & EVENT_RETURN) {
-    if (tracecmp(&trace, &rs_stack_peek(stack)->tp)) rs_stack_pop(stack);
+  sprintf((char *)output_buffer, RS_FLATTENED_CSV_FORMAT "\n",
+          RS_FLATTENED_CSV_VALUES(&stack_frame->tp, &caller->tp));
+
+  if (rs_strmemo_uniq(call_memo, output_buffer)) {
+    fputs((char *)output_buffer, stream);
   }
 }
 
@@ -157,19 +151,40 @@ static void event_hook(VALUE tpval, void *data) {
   }
 
   rb_trace_arg_t *trace_arg = rb_tracearg_from_tracepoint(tpval);
-  rs_callsite_t trace_path = tracearg_path(trace_arg);
+  rb_event_flag_t event_flag = rb_tracearg_event_flag(trace_arg);
 
-  if (rejected_path(trace_path.filepath, config)) return;
+  rs_callsite_t trace_path;
+  bool blacklisted;
+  if (event_flag & EVENT_CALL) {
+    trace_path = tracearg_path(trace_arg);
+    blacklisted = rejected_path(trace_path.filepath, config);
+  } else {
+    if (rs_stack_empty(&config->stack)) return;
+    rs_stack_frame_t *call_frame = rs_stack_peek(&config->stack);
+    trace_path = (rs_callsite_t){
+        .filepath = call_frame->tp.filepath, .lineno = call_frame->tp.lineno,
+    };
+    blacklisted = call_frame->blacklisted;
+  }
 
   rs_tracepoint_t trace = extract_full_tracevals(trace_arg, &trace_path);
   if (!strcmp("Rotoscope", StringValueCStr(trace.entity))) return;
 
-  if (config->flatten_output) {
-    rb_event_flag_t event_flag = rb_tracearg_event_flag(trace_arg);
-    log_stack_frame(config->log, &config->stack, &config->call_memo, trace,
-                    event_flag);
+  if (event_flag & EVENT_CALL) {
+    rs_stack_push(&config->stack, trace, blacklisted);
   } else {
-    log_raw_trace(config->log, trace);
+    rs_stack_pop(&config->stack);
+  }
+
+  if (blacklisted) return;
+
+  if (config->flatten_output) {
+    if (event_flag & EVENT_CALL) {
+      log_trace_event_with_caller(config->log, rs_stack_peek(&config->stack),
+                                  &config->call_memo);
+    }
+  } else {
+    log_trace_event(config->log, &trace);
   }
 }
 
@@ -298,6 +313,7 @@ VALUE rotoscope_stop_trace(VALUE self) {
   if (rb_tracepoint_enabled_p(config->tracepoint)) {
     rb_tracepoint_disable(config->tracepoint);
     config->state = RS_OPEN;
+    rs_stack_reset(&config->stack, STACK_CAPACITY);
   }
 
   return Qnil;

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -12,29 +12,30 @@
 #define INSTANCE_METHOD "instance"
 
 #define STACK_CAPACITY 500
+#define LOG_BUFFER_SIZE 1000
 
 // clang-format off
 #define _RS_COMMON_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
 #define _RS_COMMON_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
 #define _RS_COMMON_CSV_VALUES(trace)  \
-  StringValueCStr(trace.entity),      \
-  StringValueCStr(trace.method_name), \
-  trace.method_level,                 \
-  StringValueCStr(trace.filepath),    \
-  trace.lineno
+  StringValueCStr((trace)->entity),      \
+  StringValueCStr((trace)->method_name), \
+  (trace)->method_level,                 \
+  StringValueCStr((trace)->filepath),    \
+  (trace)->lineno
 
 #define RS_CSV_HEADER "event," _RS_COMMON_CSV_HEADER
 #define RS_CSV_FORMAT "%s," _RS_COMMON_CSV_FORMAT
-#define RS_CSV_VALUES(trace) trace.event, _RS_COMMON_CSV_VALUES(trace)
+#define RS_CSV_VALUES(trace) trace->event, _RS_COMMON_CSV_VALUES(trace)
 
 #define RS_FLATTENED_CSV_HEADER \
   _RS_COMMON_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
 #define RS_FLATTENED_CSV_FORMAT _RS_COMMON_CSV_FORMAT ",\"%s\",\"%s\",%s"
-#define RS_FLATTENED_CSV_VALUES(frame)           \
-  _RS_COMMON_CSV_VALUES(frame.tp),               \
-  StringValueCStr(frame.caller->tp.entity),      \
-  StringValueCStr(frame.caller->tp.method_name), \
-  frame.caller->tp.method_level
+#define RS_FLATTENED_CSV_VALUES(trace, caller_trace) \
+  _RS_COMMON_CSV_VALUES(trace),               \
+  StringValueCStr((caller_trace)->entity),      \
+  StringValueCStr((caller_trace)->method_name), \
+  (caller_trace)->method_level
 // clang-format on
 
 typedef enum {

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -14,7 +14,7 @@ static void insert_root_node(rs_stack_t *stack) {
                         .method_name = rb_unknown_str,
                         .method_level = UNKNOWN_STR,
                         .lineno = 0};
-  rs_stack_push(stack, root_trace);
+  rs_stack_push(stack, root_trace, false);
 }
 
 static void resize_buffer(rs_stack_t *stack) {
@@ -31,15 +31,16 @@ bool rs_stack_full(rs_stack_t *stack) {
 
 bool rs_stack_empty(rs_stack_t *stack) { return stack->top < 0; }
 
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace) {
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace,
+                               bool blacklisted) {
   if (rs_stack_full(stack)) {
     resize_buffer(stack);
   }
 
   rs_stack_frame_t *caller =
       rs_stack_empty(stack) ? NULL : rs_stack_peek(stack);
-  rs_stack_frame_t new_frame =
-      (rs_stack_frame_t){.tp = trace, .caller = caller};
+  rs_stack_frame_t new_frame = (rs_stack_frame_t){
+      .tp = trace, .caller = caller, .blacklisted = blacklisted};
 
   stack->contents[++stack->top] = new_frame;
   return new_frame;

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -7,6 +7,7 @@
 
 typedef struct rs_stack_frame_t {
   struct rs_tracepoint_t tp;
+  bool blacklisted;
   struct rs_stack_frame_t *caller;
 } rs_stack_frame_t;
 
@@ -19,7 +20,7 @@ typedef struct {
 void rs_stack_init(rs_stack_t *stack, unsigned int capacity);
 void rs_stack_reset(rs_stack_t *stack, unsigned int capacity);
 void rs_stack_free(rs_stack_t *stack);
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace);
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace, bool backlisted);
 bool rs_stack_empty(rs_stack_t *stack);
 bool rs_stack_full(rs_stack_t *stack);
 rs_stack_frame_t rs_stack_pop(rs_stack_t *stack);

--- a/test/monadify.rb
+++ b/test/monadify.rb
@@ -1,16 +1,14 @@
 module Monadify
+  def self.extended(base)
+    base.define_singleton_method("contents=") { |val| val }
+  end
+
   define_method("contents") do
     42
   end
 
-  def foo
-    false
-  end
-
   def monad(value)
-    foo
     contents
-    define_singleton_method("contents=") { |val| val }
     self.contents = value
   end
 end


### PR DESCRIPTION
Fixes #39
Closes #43

The issue described in #39 with getting the correct filepath and lineno for block methods is only a problem on the return event.  Instead of trying to detect this case, we can avoid it completely by just using the filepath and lineno that we got for the call event on the return event by getting it from the rotoscope stack.

Since the filepath is used for filtering, we now need to include filtered calls on the rotoscope stack, using a blacklisted flag to allow them to be skipped over for logging the non-blacklisted caller.

I used the tests from #43 in this PR.

- [x] `bin/fmt` was successfully run