### PR TITLE
Revert blacklist-tracking solution in favour of InstructionSeq check

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -12,30 +12,29 @@
 #define INSTANCE_METHOD "instance"
 
 #define STACK_CAPACITY 500
-#define LOG_BUFFER_SIZE 1000
 
 // clang-format off
 #define _RS_COMMON_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
 #define _RS_COMMON_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
 #define _RS_COMMON_CSV_VALUES(trace)  \
-  StringValueCStr((trace)->entity),      \
-  StringValueCStr((trace)->method_name), \
-  (trace)->method_level,                 \
-  StringValueCStr((trace)->filepath),    \
-  (trace)->lineno
+  StringValueCStr(trace.entity),      \
+  StringValueCStr(trace.method_name), \
+  trace.method_level,                 \
+  StringValueCStr(trace.filepath),    \
+  trace.lineno
 
 #define RS_CSV_HEADER "event," _RS_COMMON_CSV_HEADER
 #define RS_CSV_FORMAT "%s," _RS_COMMON_CSV_FORMAT
-#define RS_CSV_VALUES(trace) trace->event, _RS_COMMON_CSV_VALUES(trace)
+#define RS_CSV_VALUES(trace) trace.event, _RS_COMMON_CSV_VALUES(trace)
 
 #define RS_FLATTENED_CSV_HEADER \
   _RS_COMMON_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
 #define RS_FLATTENED_CSV_FORMAT _RS_COMMON_CSV_FORMAT ",\"%s\",\"%s\",%s"
-#define RS_FLATTENED_CSV_VALUES(trace, caller_trace) \
-  _RS_COMMON_CSV_VALUES(trace),               \
-  StringValueCStr((caller_trace)->entity),      \
-  StringValueCStr((caller_trace)->method_name), \
-  (caller_trace)->method_level
+#define RS_FLATTENED_CSV_VALUES(frame)           \
+  _RS_COMMON_CSV_VALUES(frame.tp),               \
+  StringValueCStr(frame.caller->tp.entity),      \
+  StringValueCStr(frame.caller->tp.method_name), \
+  frame.caller->tp.method_level
 // clang-format on
 
 typedef enum {

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -14,7 +14,7 @@ static void insert_root_node(rs_stack_t *stack) {
                         .method_name = rb_unknown_str,
                         .method_level = UNKNOWN_STR,
                         .lineno = 0};
-  rs_stack_push(stack, root_trace, false);
+  rs_stack_push(stack, root_trace);
 }
 
 static void resize_buffer(rs_stack_t *stack) {
@@ -31,16 +31,15 @@ bool rs_stack_full(rs_stack_t *stack) {
 
 bool rs_stack_empty(rs_stack_t *stack) { return stack->top < 0; }
 
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace,
-                               bool blacklisted) {
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace) {
   if (rs_stack_full(stack)) {
     resize_buffer(stack);
   }
 
   rs_stack_frame_t *caller =
       rs_stack_empty(stack) ? NULL : rs_stack_peek(stack);
-  rs_stack_frame_t new_frame = (rs_stack_frame_t){
-      .tp = trace, .caller = caller, .blacklisted = blacklisted};
+  rs_stack_frame_t new_frame =
+      (rs_stack_frame_t){.tp = trace, .caller = caller};
 
   stack->contents[++stack->top] = new_frame;
   return new_frame;

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -7,7 +7,6 @@
 
 typedef struct rs_stack_frame_t {
   struct rs_tracepoint_t tp;
-  bool blacklisted;
   struct rs_stack_frame_t *caller;
 } rs_stack_frame_t;
 
@@ -20,7 +19,7 @@ typedef struct {
 void rs_stack_init(rs_stack_t *stack, unsigned int capacity);
 void rs_stack_reset(rs_stack_t *stack, unsigned int capacity);
 void rs_stack_free(rs_stack_t *stack);
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace, bool backlisted);
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace);
 bool rs_stack_empty(rs_stack_t *stack);
 bool rs_stack_full(rs_stack_t *stack);
 rs_stack_frame_t rs_stack_pop(rs_stack_t *stack);

--- a/lib/rotoscope/version.rb
+++ b/lib/rotoscope/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Rotoscope
-  VERSION = "0.3.0.pre.1"
+  VERSION = "0.3.0.pre.2"
 end

--- a/test/monadify.rb
+++ b/test/monadify.rb
@@ -1,14 +1,16 @@
 module Monadify
-  def self.extended(base)
-    base.define_singleton_method("contents=") { |val| val }
-  end
-
   define_method("contents") do
     42
   end
 
+  def foo
+    false
+  end
+
   def monad(value)
+    foo
     contents
+    define_singleton_method("contents=") { |val| val }
     self.contents = value
   end
 end

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -424,22 +424,13 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
-  def test_block_defined_methods
-    contents = rotoscope_trace { Example.apply("my value!") }
+  def test_dynamic_methods_in_blacklist
+    skip <<-FAILING_TEST_CASE
+      Return events for dynamically created methods (define_method, define_singleton_method)
+      do not have the correct stack frame information (the call of a dynamically defined method
+      is correctly treated as a Ruby :call, but its return must be treated as a :c_return)
+    FAILING_TEST_CASE
 
-    assert_equal [
-      { event: "call", entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "call", entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "call", entity: "Example", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
-      { event: "call", entity: "Example", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-    ], parse_and_normalize(contents)
-  end
-
-  def test_block_defined_methods_in_blacklist
     contents = rotoscope_trace(blacklist: [MONADIFY_PATH]) { Example.apply("my value!") }
 
     assert_equal [
@@ -450,21 +441,13 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
-  def test_flatten_with_block_defined_methods_in_blacklist
+  def test_flatten_with_dynamic_methods_in_blacklist
+    # the failing test above passes when using `flatten: true` since unmatched stack returns are ignored
     contents = rotoscope_trace(blacklist: [MONADIFY_PATH], flatten: true) { Example.apply("my value!") }
 
     assert_equal [
       { entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
       { entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Example", caller_method_name: "apply", caller_method_level: "class" },
-    ], parse_and_normalize(contents)
-  end
-
-  def test_flatten_with_invoking_block_defined_methods
-    contents = rotoscope_trace(blacklist: [MONADIFY_PATH], flatten: false) { Example.contents }
-
-    assert_equal [
-      { event: "call", entity: "Example", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
     ], parse_and_normalize(contents)
   end
 


### PR DESCRIPTION
After attempting to track down a segfault sprouting from V8 after https://github.com/Shopify/rotoscope/pull/46 was merged, going to back out that change and swap it with the less-efficient https://github.com/Shopify/rotoscope/pull/43 until we can find the root cause.

At the very least, the cause of the segfault is somewhere in the diff of this PR.

- [x] `bin/fmt` was successfully run

/cc @dylanahsmith @airhorns 
