### PR TITLE
Fix caller in flattened output when call is from blacklisted context

### DIFF
--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -5,7 +5,7 @@
 #include "ruby.h"
 #include "tracepoint.h"
 
-static void insert_root_node(rs_stack_t *stack, bool blacklisted) {
+static void insert_root_node(rs_stack_t *stack) {
   VALUE rb_unknown_str = rb_str_new_cstr(UNKNOWN_STR);
   rs_tracepoint_t root_trace =
       (rs_tracepoint_t){.event = UNKNOWN_STR,
@@ -14,7 +14,7 @@ static void insert_root_node(rs_stack_t *stack, bool blacklisted) {
                         .method_name = rb_unknown_str,
                         .method_level = UNKNOWN_STR,
                         .lineno = 0};
-  rs_stack_push(stack, root_trace, blacklisted);
+  rs_stack_push(stack, root_trace);
 }
 
 static void resize_buffer(rs_stack_t *stack) {
@@ -31,14 +31,12 @@ bool rs_stack_full(rs_stack_t *stack) {
 
 bool rs_stack_empty(rs_stack_t *stack) { return stack->top < 0; }
 
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace,
-                               bool blacklisted) {
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace) {
   if (rs_stack_full(stack)) {
     resize_buffer(stack);
   }
 
-  rs_stack_frame_t new_frame =
-      (rs_stack_frame_t){.tp = trace, .blacklisted = blacklisted};
+  rs_stack_frame_t new_frame = (rs_stack_frame_t){.tp = trace};
 
   stack->contents[++stack->top] = new_frame;
   return new_frame;
@@ -74,9 +72,9 @@ rs_stack_frame_t *rs_stack_below(rs_stack_t *stack, rs_stack_frame_t *frame) {
   }
 }
 
-void rs_stack_reset(rs_stack_t *stack, bool blacklisted_root) {
+void rs_stack_reset(rs_stack_t *stack) {
   stack->top = -1;
-  insert_root_node(stack, blacklisted_root);
+  insert_root_node(stack);
 }
 
 void rs_stack_free(rs_stack_t *stack) {
@@ -86,14 +84,13 @@ void rs_stack_free(rs_stack_t *stack) {
   stack->capacity = 0;
 }
 
-void rs_stack_init(rs_stack_t *stack, unsigned int capacity,
-                   bool blacklisted_root) {
+void rs_stack_init(rs_stack_t *stack, unsigned int capacity) {
   rs_stack_frame_t *contents = ALLOC_N(rs_stack_frame_t, capacity);
   stack->contents = contents;
   stack->capacity = capacity;
   stack->top = -1;
 
-  insert_root_node(stack, blacklisted_root);
+  insert_root_node(stack);
 }
 
 void rs_stack_mark(rs_stack_t *stack) {

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -7,7 +7,6 @@
 
 typedef struct rs_stack_frame_t {
   struct rs_tracepoint_t tp;
-  bool blacklisted;
 } rs_stack_frame_t;
 
 typedef struct {
@@ -16,10 +15,10 @@ typedef struct {
   rs_stack_frame_t *contents;
 } rs_stack_t;
 
-void rs_stack_init(rs_stack_t *stack, unsigned int capacity, bool blacklisted_root);
-void rs_stack_reset(rs_stack_t *stack, bool blacklisted_root);
+void rs_stack_init(rs_stack_t *stack, unsigned int capacity);
+void rs_stack_reset(rs_stack_t *stack);
 void rs_stack_free(rs_stack_t *stack);
-rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace, bool backlisted);
+rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace);
 bool rs_stack_empty(rs_stack_t *stack);
 bool rs_stack_full(rs_stack_t *stack);
 rs_stack_frame_t rs_stack_pop(rs_stack_t *stack);

--- a/test/fixture_inner.rb
+++ b/test/fixture_inner.rb
@@ -4,6 +4,10 @@ class FixtureInner
     raise unless sum == 2
   end
 
+  def calls_sum
+    sum
+  end
+
   def sum
     1 + 1
   end

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -288,6 +288,19 @@ class RotoscopeTest < MiniTest::Test
     assert_frames_consistent contents
   end
 
+  def test_trace_saves_called_context_if_not_called_from_whitelisted_path
+    dependency = FixtureInner.new
+    contents = rotoscope_trace(flatten: true, entity_whitelist: ['FixtureInner']) do
+      dependency.calls_sum
+    end
+
+    assert_equal [
+      { entity: "FixtureInner", method_name: "sum", method_level: "instance", filepath: "/fixture_inner.rb", lineno: -1, caller_entity: "FixtureInner", caller_method_name: "calls_sum", caller_method_level: "instance" },
+    ], parse_and_normalize(contents)
+
+    assert_frames_consistent contents
+  end
+
   def test_trace_ignores_writes_in_fork
     contents = rotoscope_trace do |rotoscope|
       fork do


### PR DESCRIPTION
Closes #41

## Problem

The flattened output includes the caller entity, method name and method_level.  However, these were coming from a rotoscope stack that excluded blacklisted frames, which meant that the caller reflected the last stack frame that wasn't blacklisted rather than the true caller.

## Solution

Don't have the blacklist affect the rotoscope stack.  Instead, the blacklist only affect what events are output, not their contents.

- [x] `bin/fmt` was successfully run