### PR TITLE
Use an entity whitelist instead of a filepath blacklist

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -48,8 +48,7 @@ typedef struct {
   FILE *log;
   VALUE log_path;
   VALUE tracepoint;
-  const char **blacklist;
-  unsigned long blacklist_size;
+  VALUE entity_whitelist;
   bool flatten_output;
   pid_t pid;
   unsigned long tid;

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -17,8 +17,8 @@ typedef struct {
   rs_stack_frame_t *contents;
 } rs_stack_t;
 
-void rs_stack_init(rs_stack_t *stack, unsigned int capacity);
-void rs_stack_reset(rs_stack_t *stack, unsigned int capacity);
+void rs_stack_init(rs_stack_t *stack, unsigned int capacity, bool blacklisted_root);
+void rs_stack_reset(rs_stack_t *stack, bool blacklisted_root);
 void rs_stack_free(rs_stack_t *stack);
 rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace, bool backlisted);
 bool rs_stack_empty(rs_stack_t *stack);

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -6,12 +6,12 @@ require 'csv'
 
 class Rotoscope
   class << self
-    def new(output_path, blacklist: [], flatten: false)
-      super(output_path, blacklist, flatten)
+    def new(output_path, entity_whitelist: nil, flatten: false)
+      super(output_path, entity_whitelist, flatten)
     end
 
-    def trace(dest, blacklist: [], flatten: false, &block)
-      config = { blacklist: blacklist, flatten: flatten }
+    def trace(dest, entity_whitelist: nil, flatten: false, &block)
+      config = { entity_whitelist: entity_whitelist, flatten: flatten }
       if dest.is_a?(String)
         event_trace(dest, config, &block)
       else
@@ -45,7 +45,7 @@ class Rotoscope
     end
 
     def event_trace(dest_path, config)
-      rs = Rotoscope.new(dest_path, blacklist: config[:blacklist], flatten: config[:flatten])
+      rs = Rotoscope.new(dest_path, entity_whitelist: config[:entity_whitelist], flatten: config[:flatten])
       rs.trace { yield rs }
       rs
     ensure

--- a/test/monadify.rb
+++ b/test/monadify.rb
@@ -1,14 +1,12 @@
 module Monadify
-  def self.extended(base)
-    base.define_singleton_method("contents=") { |val| val }
-  end
+  define_singleton_method("contents=") { |val| val }
 
-  define_method("contents") do
+  define_singleton_method("contents") do
     42
   end
 
   def monad(value)
-    contents
-    self.contents = value
+    Monadify.contents
+    Monadify.contents = value
   end
 end

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -71,7 +71,7 @@ class RotoscopeTest < MiniTest::Test
   end
 
   def test_new
-    rs = Rotoscope.new(@logfile, blacklist: ['tmp'], flatten: true)
+    rs = Rotoscope.new(@logfile, entity_whitelist: %w(Foo Bar), flatten: true)
     assert rs.is_a?(Rotoscope)
   end
 
@@ -270,8 +270,8 @@ class RotoscopeTest < MiniTest::Test
     assert_frames_consistent contents
   end
 
-  def test_trace_ignores_calls_if_blacklisted
-    contents = rotoscope_trace(blacklist: [INNER_FIXTURE_PATH, OUTER_FIXTURE_PATH]) do
+  def test_trace_ignores_calls_if_not_whitelisted
+    contents = rotoscope_trace(entity_whitelist: ["FixtureOuter"]) do
       foo = FixtureOuter.new
       foo.do_work
     end
@@ -430,17 +430,17 @@ class RotoscopeTest < MiniTest::Test
     assert_equal [
       { event: "call", entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "call", entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "call", entity: "Example", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
-      { event: "call", entity: "Example", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "call", entity: "Monadify", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "return", entity: "Monadify", method_name: "contents", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "call", entity: "Monadify", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
+      { event: "return", entity: "Monadify", method_name: "contents=", method_level: "class", filepath: "/monadify.rb", lineno: -1 },
       { event: "return", entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
       { event: "return", entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
     ], parse_and_normalize(contents)
   end
 
-  def test_block_defined_methods_in_blacklist
-    contents = rotoscope_trace(blacklist: [MONADIFY_PATH]) { Example.apply("my value!") }
+  def test_block_defined_methods_not_in_whitelist
+    contents = rotoscope_trace(entity_whitelist: ['Example']) { Example.apply("my value!") }
 
     assert_equal [
       { event: "call", entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
@@ -450,21 +450,20 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
-  def test_flatten_with_block_defined_methods_in_blacklist
-    contents = rotoscope_trace(blacklist: [MONADIFY_PATH], flatten: true) { Example.apply("my value!") }
+  def test_flatten_with_block_defined_methods_in_not_in_whitelist
+    contents = rotoscope_trace(entity_whitelist: ['Example'], flatten: true) { Example.apply("my value!") }
 
     assert_equal [
-      { entity: "Example", method_name: "apply", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "<ROOT>", caller_method_name: "<UNKNOWN>", caller_method_level: "<UNKNOWN>" },
       { entity: "Example", method_name: "monad", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1, caller_entity: "Example", caller_method_name: "apply", caller_method_level: "class" },
     ], parse_and_normalize(contents)
   end
 
   def test_flatten_with_invoking_block_defined_methods
-    contents = rotoscope_trace(blacklist: [MONADIFY_PATH], flatten: false) { Example.contents }
+    contents = rotoscope_trace(entity_whitelist: ['Monadify'], flatten: false) { Monadify.contents }
 
     assert_equal [
-      { event: "call", entity: "Example", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
-      { event: "return", entity: "Example", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "call", entity: "Monadify", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
+      { event: "return", entity: "Monadify", method_name: "contents", method_level: "class", filepath: "/rotoscope_test.rb", lineno: -1 },
     ], parse_and_normalize(contents)
   end
 
@@ -537,8 +536,8 @@ class RotoscopeTest < MiniTest::Test
     assert_equal csv_string.scan(/\Acall/).size, csv_string.scan(/\Areturn/).size
   end
 
-  def rotoscope_trace(blacklist: [], flatten: false)
-    Rotoscope.trace(@logfile, blacklist: blacklist, flatten: flatten) { |rotoscope| yield rotoscope }
+  def rotoscope_trace(entity_whitelist: nil, flatten: false)
+    Rotoscope.trace(@logfile, entity_whitelist: entity_whitelist, flatten: flatten) { |rotoscope| yield rotoscope }
     File.read(@logfile)
   end
 


### PR DESCRIPTION
## Problem

Previously we were using a file path blacklist, which excluded call or return events where the caller was on the blacklist.  However, this still included many calls to builtin ruby objects (e.g. Symbol, String, Hash, etc.) since they were being called from application code.  This resulted in a lot of calls being logged that we didn't care about.

I think what we actually care about are calls between entities defined by the application.

## Solution

Use an entity whitelist, which will only include calls between entities in the whitelist.

Note that this may also include calls that weren't previously included, when the call is to a method on the entity that is defined in a gem.  In many cases this seems desirable, since we care about calls to active record objects, where many of those methods being called are actually defined within active record.  In other cases this may not be desirable, like when Object methods are called on an entity (e.g. Object#nil?), but we already weren't filtering these calls.

- [x] `bin/fmt` was successfully run
