### PR TITLE
Remove invalid caller stack pointers

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -172,10 +172,10 @@ static void event_hook(VALUE tpval, void *data) {
 
   if (config->flatten_output) {
     if (event_flag & EVENT_CALL) {
-      rs_stack_frame_t *caller = rs_stack_peek(&config->stack)->caller;
-      while (caller && caller->blacklisted) {
-        caller = caller->caller;
-      }
+      rs_stack_frame_t *caller = rs_stack_peek(&config->stack);
+      do {
+        caller = rs_stack_below(&config->stack, caller);
+      } while (caller && caller->blacklisted);
       if (caller) {
         log_trace_event_with_caller(config->log, rs_stack_peek(&config->stack),
                                     caller, &config->call_memo);

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -37,10 +37,8 @@ rs_stack_frame_t rs_stack_push(rs_stack_t *stack, rs_tracepoint_t trace,
     resize_buffer(stack);
   }
 
-  rs_stack_frame_t *caller =
-      rs_stack_empty(stack) ? NULL : rs_stack_peek(stack);
-  rs_stack_frame_t new_frame = (rs_stack_frame_t){
-      .tp = trace, .caller = caller, .blacklisted = blacklisted};
+  rs_stack_frame_t new_frame =
+      (rs_stack_frame_t){.tp = trace, .blacklisted = blacklisted};
 
   stack->contents[++stack->top] = new_frame;
   return new_frame;
@@ -62,6 +60,18 @@ rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack) {
   }
 
   return &stack->contents[stack->top];
+}
+
+rs_stack_frame_t *rs_stack_below(rs_stack_t *stack, rs_stack_frame_t *frame) {
+  if (frame < stack->contents || frame > stack->contents + stack->top) {
+    fprintf(stderr, "Invalid stack frame (bottom: %p, frame: %p, top: %p)\n",
+            stack->contents, frame, &stack->contents[stack->top]);
+    exit(1);
+  } else if (stack->contents == frame) {
+    return NULL;
+  } else {
+    return frame - 1;
+  }
 }
 
 void rs_stack_reset(rs_stack_t *stack, bool blacklisted_root) {

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -8,7 +8,6 @@
 typedef struct rs_stack_frame_t {
   struct rs_tracepoint_t tp;
   bool blacklisted;
-  struct rs_stack_frame_t *caller;
 } rs_stack_frame_t;
 
 typedef struct {
@@ -25,6 +24,7 @@ bool rs_stack_empty(rs_stack_t *stack);
 bool rs_stack_full(rs_stack_t *stack);
 rs_stack_frame_t rs_stack_pop(rs_stack_t *stack);
 rs_stack_frame_t *rs_stack_peek(rs_stack_t *stack);
+rs_stack_frame_t *rs_stack_below(rs_stack_t *stack, rs_stack_frame_t *frame);
 void rs_stack_mark(rs_stack_t *stack);
 
 #endif


### PR DESCRIPTION
## Problem

I noticed that the v8 segfaults mentioned in https://github.com/Shopify/rotoscope/pull/48 were happening in CI, but just weren't as noticeable now because it was treating the segfault as an "infrastructure issue" and re-running the tests for that container on another container.

I tracked down the problem to the `caller` field on the rs_stack_frame_t which is a pointer to an element of the rs_stack_t contents array.  However, that contents array get reallocated to grow the stack, leaving the `caller` field on the stack frames pointer to freed memory.

## Solution

I removed the `caller` field from `rs_stack_frame_t` and instead added a rs_stack_below function that will take a frame and get the frame below it on the stack.  That function is given a reference to rs_stack_t which is used to make sure the passed in frame points to a valid frame on the stack.  This is then used to iterate over blacklisted stack frame when getting the non-blacklisted caller.

- [x] `bin/fmt` was successfully run
