### PR TITLE
Use direct caller in flattened output even if its callsite is blacklisted

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -175,14 +175,11 @@ static void event_hook(VALUE tpval, void *data) {
 
   if (config->flatten_output) {
     if (event_flag & EVENT_CALL) {
-      rs_stack_frame_t *caller = rs_stack_peek(&config->stack);
-      do {
-        caller = rs_stack_below(&config->stack, caller);
-      } while (caller && caller->blacklisted);
-      if (caller) {
-        log_trace_event_with_caller(config->log, rs_stack_peek(&config->stack),
-                                    caller, &config->call_memo);
-      }
+      rs_stack_frame_t *stack_frame = rs_stack_peek(&config->stack);
+      rs_stack_frame_t *caller_frame =
+          rs_stack_below(&config->stack, stack_frame);
+      log_trace_event_with_caller(config->log, stack_frame, caller_frame,
+                                  &config->call_memo);
     }
   } else {
     log_trace_event(config->log, &trace);

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -347,6 +347,20 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
+  def test_trace_flatten_with_blacklisted_caller
+    foo = FixtureOuter.new
+    contents = rotoscope_trace(blacklist: ['/rotoscope_test.rb'], flatten: true) do
+      foo.do_work
+    end
+
+    assert_equal [
+      { entity: "FixtureInner", method_name: "do_work", method_level: "instance", filepath: "/fixture_outer.rb", lineno: -1,
+        caller_entity: "FixtureOuter", caller_method_name: "do_work", caller_method_level: "instance" },
+      { entity: "FixtureInner", method_name: "sum", method_level: "instance", filepath: "/fixture_inner.rb", lineno: -1,
+        caller_entity: "FixtureInner", caller_method_name: "do_work", caller_method_level: "instance" },
+    ], parse_and_normalize(contents)
+  end
+
   def test_trace_uses_io_objects
     string_io = StringIO.new
     Rotoscope.trace(string_io) do


### PR DESCRIPTION
Similar to https://github.com/Shopify/rotoscope/pull/51, but for a different reason and rewritten due to not having an entity blacklist anymore.

## Problem

In the flattened output we were trying to mimic the behaviour we had before where we got the flattened output from the non-flattened output.  That behaviour worked by keeping a stack of previous calls that is pushed for each call and popped for each return, so we could get the caller entity and method from the parent call.  Since the non-flattened output would exclude blacklisted calls, it would end up getting the parent non-blacklisted caller info rather than the direct caller info.

The problem with that approach for the flattened output is that we are actually filtering based on the call site path, so if the parent call was blacklisted then that means the caller's caller was blacklisted, which isn't relevant for the current call.

## Solution

We already return without logging if the call came from a blacklisted file path, so we just use the caller's entity and method unconditionally in the flattened output.

- [x] `bin/fmt` was successfully run