### PR TITLE
Escape method name in CSV output

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -17,24 +17,24 @@
 // clang-format off
 #define _RS_COMMON_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
 #define _RS_COMMON_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
-#define _RS_COMMON_CSV_VALUES(trace)  \
+#define _RS_COMMON_CSV_VALUES(trace, method_name)  \
   StringValueCStr((trace)->entity),      \
-  StringValueCStr((trace)->method_name), \
+  StringValueCStr(method_name),          \
   (trace)->method_level,                 \
   StringValueCStr((trace)->filepath),    \
   (trace)->lineno
 
 #define RS_CSV_HEADER "event," _RS_COMMON_CSV_HEADER
 #define RS_CSV_FORMAT "%s," _RS_COMMON_CSV_FORMAT
-#define RS_CSV_VALUES(trace) trace->event, _RS_COMMON_CSV_VALUES(trace)
+#define RS_CSV_VALUES(trace, method_name) trace->event, _RS_COMMON_CSV_VALUES(trace, method_name)
 
 #define RS_FLATTENED_CSV_HEADER \
   _RS_COMMON_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
 #define RS_FLATTENED_CSV_FORMAT _RS_COMMON_CSV_FORMAT ",\"%s\",\"%s\",%s"
-#define RS_FLATTENED_CSV_VALUES(trace, caller_trace) \
-  _RS_COMMON_CSV_VALUES(trace),               \
-  StringValueCStr((caller_trace)->entity),      \
-  StringValueCStr((caller_trace)->method_name), \
+#define RS_FLATTENED_CSV_VALUES(trace, caller_trace, method_name, caller_method_name) \
+  _RS_COMMON_CSV_VALUES(trace, method_name), \
+  StringValueCStr((caller_trace)->entity),   \
+  StringValueCStr(caller_method_name),       \
   (caller_trace)->method_level
 // clang-format on
 


### PR DESCRIPTION
Fixes #56

Since we blacklist tests, I didn't worry about performance for the slow path where we need to escape CSV strings.  For the fast path we simply check if the string has a `"` character.  For the slow path I used String#gsub to replace `"` with `""`.

- [x] `bin/fmt` was successfully run