### PR TITLE
Reorder CSV fields to simplify use through an awk script

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -15,27 +15,30 @@
 #define LOG_BUFFER_SIZE 1000
 
 // clang-format off
-#define _RS_COMMON_CSV_HEADER "entity,method_name,method_level,filepath,lineno"
-#define _RS_COMMON_CSV_FORMAT "\"%s\",\"%s\",%s,\"%s\",%d"
-#define _RS_COMMON_CSV_VALUES(trace, method_name)  \
-  StringValueCStr((trace)->entity),      \
-  StringValueCStr(method_name),          \
-  (trace)->method_level,                 \
-  StringValueCStr((trace)->filepath),    \
-  (trace)->lineno
 
-#define RS_CSV_HEADER "event," _RS_COMMON_CSV_HEADER
-#define RS_CSV_FORMAT "%s," _RS_COMMON_CSV_FORMAT
-#define RS_CSV_VALUES(trace, method_name) trace->event, _RS_COMMON_CSV_VALUES(trace, method_name)
+#define RS_CSV_HEADER "event,entity,filepath,lineno,method_name,method_level"
+#define RS_CSV_FORMAT "%s,\"%s\",\"%s\",%d,\"%s\",%s"
+#define RS_CSV_VALUES(trace, method_name) \
+  trace->event,                           \
+  StringValueCStr((trace)->entity),       \
+  StringValueCStr((trace)->filepath),     \
+  (trace)->lineno,                        \
+  StringValueCStr(method_name),           \
+  (trace)->method_level
 
 #define RS_FLATTENED_CSV_HEADER \
-  _RS_COMMON_CSV_HEADER ",caller_entity,caller_method_name,caller_method_level"
-#define RS_FLATTENED_CSV_FORMAT _RS_COMMON_CSV_FORMAT ",\"%s\",\"%s\",%s"
+  "entity,caller_entity,filepath,lineno,method_name,method_level,caller_method_name,caller_method_level"
+#define RS_FLATTENED_CSV_FORMAT "\"%s\",\"%s\",\"%s\",%d,\"%s\",%s,\"%s\",%s"
 #define RS_FLATTENED_CSV_VALUES(trace, caller_trace, method_name, caller_method_name) \
-  _RS_COMMON_CSV_VALUES(trace, method_name), \
-  StringValueCStr((caller_trace)->entity),   \
-  StringValueCStr(caller_method_name),       \
+  StringValueCStr((trace)->entity),        \
+  StringValueCStr((caller_trace)->entity), \
+  StringValueCStr((trace)->filepath),      \
+  (trace)->lineno,                         \
+  StringValueCStr(method_name),            \
+  (trace)->method_level,                   \
+  StringValueCStr(caller_method_name),     \
   (caller_trace)->method_level
+
 // clang-format on
 
 typedef enum {


### PR DESCRIPTION
~~Based on top of https://github.com/Shopify/rotoscope/pull/60 to avoid conflicts after it is merged~~

## Problem

We are using an awk script (for performance reasons) on the rotoscope CSV output that uses the entity and filepath fields.  We are using a comma as a field separator, which doesn't properly split quoted CSV fields with commas in them.  We also have tests that have commas in their method names.

## Solution

Workaround the issue by moving the method name fields after the entity and filepath fields in the CSV output.

- [x] `bin/fmt` was successfully run
