### PR TITLE
Add a way to pass custom headers

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -51,6 +51,7 @@ typedef struct {
   FILE *log;
   VALUE log_path;
   VALUE tracepoint;
+  const char *header;
   const char **blacklist;
   unsigned long blacklist_size;
   bool flatten_output;

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -6,12 +6,12 @@ require 'csv'
 
 class Rotoscope
   class << self
-    def new(output_path, blacklist: [], flatten: false)
-      super(output_path, blacklist, flatten)
+    def new(output_path, blacklist: [], flatten: false, header: nil)
+      super(output_path, blacklist, flatten, header)
     end
 
-    def trace(dest, blacklist: [], flatten: false, &block)
-      config = { blacklist: blacklist, flatten: flatten }
+    def trace(dest, blacklist: [], flatten: false, header: nil, &block)
+      config = { blacklist: blacklist, flatten: flatten, header: header }
       if dest.is_a?(String)
         event_trace(dest, config, &block)
       else
@@ -45,7 +45,7 @@ class Rotoscope
     end
 
     def event_trace(dest_path, config)
-      rs = Rotoscope.new(dest_path, blacklist: config[:blacklist], flatten: config[:flatten])
+      rs = Rotoscope.new(dest_path, blacklist: config[:blacklist], flatten: config[:flatten], header: config[:header])
       rs.trace { yield rs }
       rs
     ensure

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -566,6 +566,13 @@ class RotoscopeTest < MiniTest::Test
     ], parse_and_normalize(contents)
   end
 
+  def test_custom_headers
+    header = 'event,entity_name,path,line,method_name,method_level'
+    contents = rotoscope_trace(header: header) { Example.new.normal_method }
+
+    assert_equal header.split(','), CSV.parse(contents, headers: true).headers
+  end
+
   private
 
   def parse_and_normalize(csv_string)
@@ -585,8 +592,8 @@ class RotoscopeTest < MiniTest::Test
     assert_equal csv_string.scan(/\Acall/).size, csv_string.scan(/\Areturn/).size
   end
 
-  def rotoscope_trace(blacklist: [], flatten: false)
-    Rotoscope.trace(@logfile, blacklist: blacklist, flatten: flatten) { |rotoscope| yield rotoscope }
+  def rotoscope_trace(blacklist: [], flatten: false, header: nil)
+    Rotoscope.trace(@logfile, blacklist: blacklist, flatten: flatten, header: header) { |rotoscope| yield rotoscope }
     File.read(@logfile)
   end
 


### PR DESCRIPTION
Add a way to pass custom headers

- When rotoscope creates the CSV, the headers are static, but in a real world situation, the traced application will probably need to add more data in the CSV
- This PR is the first in a batch to allow rotoscope to add more data in the CSV based on what the application needs. This PR implements a way to pass custom headers to the Rotoscope object; if none are explicitly passed, rotoscope will use the default ones

