### PR TITLE
Remove support for the `flatten: false` option

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -127,13 +127,6 @@ VALUE escape_csv_string(VALUE string) {
   return rb_funcall(string, id_gsub, 2, str_quote, str_escaped_quote);
 }
 
-static void log_trace_event(FILE *stream, rs_tracepoint_t *trace) {
-  VALUE escaped_method_name = escape_csv_string(trace->method_name);
-  fprintf(stream, RS_CSV_FORMAT "\n",
-          RS_CSV_VALUES(trace, escaped_method_name));
-  RB_GC_GUARD(escaped_method_name);
-}
-
 unsigned char output_buffer[LOG_BUFFER_SIZE];
 static void log_trace_event_with_caller(FILE *stream,
                                         rs_stack_frame_t *stack_frame,
@@ -142,10 +135,9 @@ static void log_trace_event_with_caller(FILE *stream,
   VALUE escaped_method_name = escape_csv_string(stack_frame->tp.method_name);
   VALUE escaped_caller_method_name =
       escape_csv_string(caller_frame->tp.method_name);
-  snprintf(
-      (char *)output_buffer, LOG_BUFFER_SIZE, RS_FLATTENED_CSV_FORMAT "\n",
-      RS_FLATTENED_CSV_VALUES(&stack_frame->tp, &caller_frame->tp,
-                              escaped_method_name, escaped_caller_method_name));
+  snprintf((char *)output_buffer, LOG_BUFFER_SIZE, RS_CSV_FORMAT "\n",
+           RS_CSV_VALUES(&stack_frame->tp, &caller_frame->tp,
+                         escaped_method_name, escaped_caller_method_name));
   RB_GC_GUARD(escaped_method_name);
   RB_GC_GUARD(escaped_caller_method_name);
 
@@ -191,16 +183,12 @@ static void event_hook(VALUE tpval, void *data) {
   }
   if (blacklisted) return;
 
-  if (config->flatten_output) {
-    if (event_flag & EVENT_CALL) {
-      rs_stack_frame_t *stack_frame = rs_stack_peek(&config->stack);
-      rs_stack_frame_t *caller_frame =
-          rs_stack_below(&config->stack, stack_frame);
-      log_trace_event_with_caller(config->log, stack_frame, caller_frame,
-                                  &config->call_memo);
-    }
-  } else {
-    log_trace_event(config->log, &trace);
+  if (event_flag & EVENT_CALL) {
+    rs_stack_frame_t *stack_frame = rs_stack_peek(&config->stack);
+    rs_stack_frame_t *caller_frame =
+        rs_stack_below(&config->stack, stack_frame);
+    log_trace_event_with_caller(config->log, stack_frame, caller_frame,
+                                &config->call_memo);
   }
 }
 
@@ -287,16 +275,15 @@ void copy_blacklist(Rotoscope *config, VALUE blacklist) {
 
 VALUE initialize(int argc, VALUE *argv, VALUE self) {
   Rotoscope *config = get_config(self);
-  VALUE output_path, blacklist, flatten;
+  VALUE output_path, blacklist;
 
-  rb_scan_args(argc, argv, "12", &output_path, &blacklist, &flatten);
+  rb_scan_args(argc, argv, "11", &output_path, &blacklist);
   Check_Type(output_path, T_STRING);
 
   if (!NIL_P(blacklist)) {
     copy_blacklist(config, blacklist);
   }
 
-  config->flatten_output = RTEST(flatten);
   config->log_path = output_path;
   config->log = fopen(StringValueCStr(config->log_path), "w");
 
@@ -306,10 +293,7 @@ VALUE initialize(int argc, VALUE *argv, VALUE self) {
     exit(1);
   }
 
-  if (config->flatten_output)
-    write_csv_header(config->log, RS_FLATTENED_CSV_HEADER);
-  else
-    write_csv_header(config->log, RS_CSV_HEADER);
+  write_csv_header(config->log, RS_CSV_HEADER);
 
   rs_stack_init(&config->stack, STACK_CAPACITY);
   config->call_memo = NULL;
@@ -350,6 +334,7 @@ VALUE rotoscope_mark(int argc, VALUE *argv, VALUE self) {
   Rotoscope *config = get_config(self);
   if (config->log != NULL && !in_fork(config)) {
     rs_strmemo_free(config->call_memo);
+    config->call_memo = NULL;
     fprintf(config->log, "--- %s\n", StringValueCStr(str));
   }
   return Qnil;

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -16,20 +16,10 @@
 
 // clang-format off
 
-#define RS_CSV_HEADER "event,entity,filepath,lineno,method_name,method_level"
-#define RS_CSV_FORMAT "%s,\"%s\",\"%s\",%d,\"%s\",%s"
-#define RS_CSV_VALUES(trace, method_name) \
-  trace->event,                           \
-  StringValueCStr((trace)->entity),       \
-  StringValueCStr((trace)->filepath),     \
-  (trace)->lineno,                        \
-  StringValueCStr(method_name),           \
-  (trace)->method_level
-
-#define RS_FLATTENED_CSV_HEADER \
+#define RS_CSV_HEADER \
   "entity,caller_entity,filepath,lineno,method_name,method_level,caller_method_name,caller_method_level"
-#define RS_FLATTENED_CSV_FORMAT "\"%s\",\"%s\",\"%s\",%d,\"%s\",%s,\"%s\",%s"
-#define RS_FLATTENED_CSV_VALUES(trace, caller_trace, method_name, caller_method_name) \
+#define RS_CSV_FORMAT "\"%s\",\"%s\",\"%s\",%d,\"%s\",%s,\"%s\",%s"
+#define RS_CSV_VALUES(trace, caller_trace, method_name, caller_method_name) \
   StringValueCStr((trace)->entity),        \
   StringValueCStr((caller_trace)->entity), \
   StringValueCStr((trace)->filepath),      \
@@ -53,7 +43,6 @@ typedef struct {
   VALUE tracepoint;
   const char **blacklist;
   unsigned long blacklist_size;
-  bool flatten_output;
   pid_t pid;
   unsigned long tid;
   rs_state state;

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -6,12 +6,12 @@ require 'csv'
 
 class Rotoscope
   class << self
-    def new(output_path, blacklist: [], flatten: false)
-      super(output_path, blacklist, flatten)
+    def new(output_path, blacklist: [])
+      super(output_path, blacklist)
     end
 
-    def trace(dest, blacklist: [], flatten: false, &block)
-      config = { blacklist: blacklist, flatten: flatten }
+    def trace(dest, blacklist: [], &block)
+      config = { blacklist: blacklist }
       if dest.is_a?(String)
         event_trace(dest, config, &block)
       else
@@ -45,7 +45,7 @@ class Rotoscope
     end
 
     def event_trace(dest_path, config)
-      rs = Rotoscope.new(dest_path, blacklist: config[:blacklist], flatten: config[:flatten])
+      rs = Rotoscope.new(dest_path, blacklist: config[:blacklist])
       rs.trace { yield rs }
       rs
     ensure


### PR DESCRIPTION
In Shopify we only use rotoscope with `flatten: true`, so we could remove support for `flatten: false`.

You can see how the event_hook function is a lot more readable now that we don't have to handle some of the concerns specific to non-flattened output (e.g. getting the true callsite on a return event).

- [x] `bin/fmt` was successfully run