### PR TITLE
Write to IO object form C rather than to a stdio stream

### DIFF
--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -15,7 +15,7 @@
 #include "tracepoint.h"
 
 VALUE cRotoscope, cTracePoint;
-ID id_initialize, id_gsub;
+ID id_initialize, id_gsub, id_close;
 VALUE str_quote, str_escaped_quote, str_header;
 
 static unsigned long gettid() {
@@ -290,7 +290,6 @@ VALUE initialize(int argc, VALUE *argv, VALUE self) {
   VALUE output, blacklist;
 
   rb_scan_args(argc, argv, "11", &output, &blacklist);
-  output = rb_io_check_io(output);
 
   if (!NIL_P(blacklist)) {
     copy_blacklist(config, blacklist);
@@ -351,7 +350,7 @@ VALUE rotoscope_close(VALUE self) {
   rb_tracepoint_disable(config->tracepoint);
   config->state = RS_OPEN;
   if (!in_fork(config)) {
-    rb_io_close(config->log);
+    rb_funcall(config->log, id_close, 0);
   }
   config->state = RS_CLOSED;
   return Qtrue;
@@ -384,6 +383,7 @@ void Init_rotoscope(void) {
 
   id_initialize = rb_intern("initialize");
   id_gsub = rb_intern("gsub");
+  id_close = rb_intern("close");
 
   str_quote = rb_str_new_literal("\"");
   rb_global_variable(&str_quote);

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -38,6 +38,7 @@ typedef enum {
 } rs_state;
 
 typedef struct {
+  VALUE self;
   VALUE log;
   VALUE tracepoint;
   const char **blacklist;

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -48,6 +48,7 @@ typedef struct {
   rs_state state;
   rs_stack_t stack;
   rs_strmemo_t *call_memo;
+  VALUE output_buffer;
 } Rotoscope;
 
 typedef struct {

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -38,8 +38,7 @@ typedef enum {
 } rs_state;
 
 typedef struct {
-  FILE *log;
-  VALUE log_path;
+  VALUE log;
   VALUE tracepoint;
   const char **blacklist;
   unsigned long blacklist_size;

--- a/ext/rotoscope/strmemo.c
+++ b/ext/rotoscope/strmemo.c
@@ -11,9 +11,9 @@ static unsigned long hash_djb2(unsigned char *str) {
   return hash;
 }
 
-bool rs_strmemo_uniq(rs_strmemo_t **calls, unsigned char *entry) {
+bool rs_strmemo_uniq(rs_strmemo_t **calls, char *entry) {
   rs_strmemo_t *c = NULL;
-  unsigned long hashkey = hash_djb2(entry);
+  unsigned long hashkey = hash_djb2((unsigned char *)entry);
 
   HASH_FIND_INT(*calls, &hashkey, c);
   if (c != NULL) return false;

--- a/ext/rotoscope/strmemo.h
+++ b/ext/rotoscope/strmemo.h
@@ -8,7 +8,7 @@ typedef struct {
   UT_hash_handle hh;
 } rs_strmemo_t;
 
-bool rs_strmemo_uniq(rs_strmemo_t **calls, unsigned char *entry);
+bool rs_strmemo_uniq(rs_strmemo_t **calls, char *entry);
 void rs_strmemo_free(rs_strmemo_t *calls);
 
 #endif

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -1,26 +1,27 @@
 # frozen_string_literal: true
 require 'rotoscope/rotoscope'
-require 'fileutils'
-require 'tempfile'
 require 'csv'
 
 class Rotoscope
   class << self
-    def new(output_path, blacklist: [], &block)
-      output = File.open(output_path, 'w')
-      prevent_flush_from_finalizer_in_fork(output)
-      obj = super(output, blacklist)
-      obj.log_path = output_path
-      obj
+    def new(output, blacklist: [])
+      if output.is_a?(String)
+        io = File.open(output, 'w')
+        prevent_flush_from_finalizer_in_fork(io)
+        obj = super(io, blacklist)
+        obj.log_path = output
+        obj
+      else
+        super(output, blacklist)
+      end
     end
 
     def trace(dest, blacklist: [], &block)
-      config = { blacklist: blacklist }
-      if dest.is_a?(String)
-        event_trace(dest, config, &block)
-      else
-        io_event_trace(dest, config, &block)
-      end
+      rs = new(dest, blacklist: blacklist)
+      rs.trace { yield rs }
+      rs
+    ensure
+      rs.close if rs && dest.is_a?(String)
     end
 
     private
@@ -34,37 +35,6 @@ class Rotoscope
         IO.for_fd(io.fileno).close
       end
       ObjectSpace.define_finalizer(io, finalizer)
-    end
-
-    def with_temp_file(name)
-      temp_file = Tempfile.new(name)
-      yield temp_file
-    ensure
-      temp_file.close! if temp_file
-    end
-
-    def temp_event_trace(config, block)
-      with_temp_file("rotoscope_output") do |temp_file|
-        rs = event_trace(temp_file.path, config, &block)
-        yield rs
-        rs
-      end
-    end
-
-    def io_event_trace(dest_io, config, &block)
-      temp_event_trace(config, block) do |rs|
-        File.open(rs.log_path) do |rs_file|
-          IO.copy_stream(rs_file, dest_io)
-        end
-      end
-    end
-
-    def event_trace(dest_path, config)
-      rs = Rotoscope.new(dest_path, blacklist: config[:blacklist])
-      rs.trace { yield rs }
-      rs
-    ensure
-      rs.close if rs
     end
   end
 

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -160,6 +160,7 @@ class RotoscopeTest < MiniTest::Test
     rs.start_trace
     Example.new.normal_method
     rs.stop_trace
+    rs.io.flush
     rs.close
     contents = File.read(@logfile)
 


### PR DESCRIPTION
Paired with @Edouard-chin on most of this
cc @jahfer 

## Problem

We would like to delegate the CSV writing to the application, where currently it is being done in C using a stdio stream.

## Solution

As an intermediate refactor, we moved to using ruby methods for writing to an IO object instead of using a stdio stream.

This turned up a couple of issues that we now have to handle:
* Prevent the IO buffer from being flushed in a fork when the object is garbage collected using a GC finalizer that closes the underlying file descriptor.  We had to do something similar before with the stdio stream, just now we moved the logic to ruby code.
* Return early in the event_hook if the Rotoscope object is being garbage collected and the event is from another objects finalizer block, since ruby objects held by the Rotoscope object may have already been collected.

Now that we are working directly with an IO object, we don't need to first write to a temp file as was being done in lib/rotoscope.rb to support this.  E.g. this means we can write directly to a shell pipeline process like `awk '!seen[$0]++' - | gzip`

I tested this branch in Shopify CI and it didn't cause a performance regression.

- [x] `bin/fmt` was successfully run