### PR TITLE
Move logging logic to a ruby method

### DIFF
--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -7,45 +7,17 @@
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)
 #define EVENT_RETURN (RUBY_EVENT_RETURN | RUBY_EVENT_C_RETURN)
 
-#define CLASS_METHOD "class"
-#define INSTANCE_METHOD "instance"
-
 #define STACK_CAPACITY 500
-#define LOG_BUFFER_SIZE 1000
-
-// clang-format off
-
-#define RS_CSV_HEADER \
-  "entity,caller_entity,filepath,lineno,method_name,method_level,caller_method_name,caller_method_level"
-#define RS_CSV_FORMAT "\"%s\",\"%s\",\"%s\",%d,\"%s\",%s,\"%s\",%s"
-#define RS_CSV_VALUES(method, caller_method, call_site) \
-  StringValueCStr((method).class_name),        \
-  StringValueCStr((caller_method).class_name), \
-  StringValueCStr((call_site)->filepath),      \
-  (call_site)->lineno,                         \
-  StringValueCStr(method.name),                \
-  (method).level,                              \
-  StringValueCStr(caller_method.name),         \
-  (caller_method).level
-
-// clang-format on
-
-typedef enum {
-  RS_CLOSED = 0,
-  RS_OPEN,
-  RS_TRACING,
-} rs_state;
 
 typedef struct {
   VALUE self;
-  VALUE log;
   VALUE tracepoint;
-  VALUE blacklist;
   pid_t pid;
   unsigned long tid;
-  rs_state state;
+  bool tracing;
   rs_stack_t stack;
-  VALUE output_buffer;
+  rs_stack_frame_t *caller;
+  rs_callsite_t callsite;
 } Rotoscope;
 
 #endif

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -34,6 +34,7 @@ class Rotoscope
     end
     @pid = Process.pid
     @thread = Thread.current
+    @output_buffer = String.new
 
     io << HEADER
   end
@@ -97,15 +98,18 @@ class Rotoscope
     call_method_level = singleton_method? ? 'class' : 'instance'
     method_name = escape_csv_string(self.method_name)
 
-    io <<
+    buffer = @output_buffer
+    buffer.clear
+    buffer <<
       '"' << class_name << '",' \
       '"' << caller_class_name << '",' \
       '"' << caller_path << '",' \
-      << caller_lineno << ',' \
+      << caller_lineno.to_s << ',' \
       '"' << method_name << '",' \
       << call_method_level << ',' \
       '"' << caller_method_name << '",' \
       << caller_method_level << "\n"
+    io.write(buffer)
   end
 
   def escape_csv_string(string)

--- a/lib/rotoscope.rb
+++ b/lib/rotoscope.rb
@@ -3,60 +3,70 @@ require 'rotoscope/rotoscope'
 require 'csv'
 
 class Rotoscope
-  class << self
-    def new(output, blacklist: [])
-      unless blacklist.is_a?(Regexp)
-        blacklist = Regexp.union(blacklist)
-      end
-      if output.is_a?(String)
-        io = File.open(output, 'w')
-        prevent_flush_from_finalizer_in_fork(io)
-        obj = super(io, blacklist)
-        obj.log_path = output
-        obj
-      else
-        super(output, blacklist)
-      end
-    end
+  HEADER = "entity,caller_entity,filepath,lineno,method_name,method_level,caller_method_name,caller_method_level\n"
+  private_constant :HEADER
 
+  class << self
     def trace(dest, blacklist: [])
       rs = new(dest, blacklist: blacklist)
       rs.trace { yield rs }
       rs
     ensure
-      rs.close if rs && dest.is_a?(String)
-    end
-
-    private
-
-    def prevent_flush_from_finalizer_in_fork(io)
-      pid = Process.pid
-      finalizer = lambda do |_|
-        next if Process.pid == pid
-        # close the file descriptor from another IO object so
-        # buffered writes aren't flushed
-        IO.for_fd(io.fileno).close
-      end
-      ObjectSpace.define_finalizer(io, finalizer)
+      rs.io.close if rs && dest.is_a?(String)
     end
   end
 
-  attr_accessor :log_path
+  attr_reader :io, :log_path, :blacklist
+
+  def initialize(output, blacklist: [])
+    unless blacklist.is_a?(Regexp)
+      blacklist = Regexp.union(blacklist)
+    end
+    @blacklist = blacklist
+
+    if output.is_a?(String)
+      @log_path = output
+      @io = File.open(output, 'w')
+      prevent_flush_from_finalizer_in_fork(@io)
+    else
+      @log_path = nil
+      @io = output
+    end
+    @pid = Process.pid
+    @thread = Thread.current
+
+    io << HEADER
+  end
 
   def mark(message = "")
-    state = self.state
-    if state == :tracing
+    was_tracing = tracing?
+    if was_tracing
       # stop tracing to avoid logging these io method calls
       stop_trace
     end
-    io.write("--- ")
-    io.puts(message)
+    if @pid == Process.pid && @thread == Thread.current
+      io.write("--- ")
+      io.puts(message)
+    end
   ensure
-    start_trace if state == :tracing
+    start_trace if was_tracing
+  end
+
+  def close
+    stop_trace
+    if @pid == Process.pid && @thread == Thread.current
+      io.close
+    end
+    true
   end
 
   def closed?
-    state == :closed
+    io.closed?
+  end
+
+  def state
+    return :closed if io.closed?
+    tracing? ? :tracing : :open
   end
 
   def inspect
@@ -69,5 +79,47 @@ class Rotoscope
     return log_path if log_path.length < 40
     chars = log_path.chars
     "#{chars.first(17).join('')}...#{chars.last(20).join('')}"
+  end
+
+  def log_call
+    return if blacklist.match?(caller_path)
+
+    if caller_method_name.nil?
+      caller_class_name = '<ROOT>'
+      caller_method_name = '<UNKNOWN>'
+      caller_method_level = '<UNKNOWN>'
+    else
+      caller_class_name = self.caller_class_name
+      caller_method_name = escape_csv_string(self.caller_method_name)
+      caller_method_level = caller_singleton_method? ? 'class' : 'instance'
+    end
+
+    call_method_level = singleton_method? ? 'class' : 'instance'
+    method_name = escape_csv_string(self.method_name)
+
+    io <<
+      '"' << class_name << '",' \
+      '"' << caller_class_name << '",' \
+      '"' << caller_path << '",' \
+      << caller_lineno << ',' \
+      '"' << method_name << '",' \
+      << call_method_level << ',' \
+      '"' << caller_method_name << '",' \
+      << caller_method_level << "\n"
+  end
+
+  def escape_csv_string(string)
+    string.include?('"') ? string.gsub('"', '""') : string
+  end
+
+  def prevent_flush_from_finalizer_in_fork(io)
+    pid = Process.pid
+    finalizer = lambda do |_|
+      next if Process.pid == pid
+      # close the file descriptor from another IO object so
+      # buffered writes aren't flushed
+      IO.for_fd(io.fileno).close
+    end
+    ObjectSpace.define_finalizer(io, finalizer)
   end
 end


### PR DESCRIPTION
~~Depends on https://github.com/Shopify/rotoscope/pull/67~~
Paired with @Edouard-chin for some of the early work on this

## Problem

We want to give more control to the application by letting it do the logging.  This requires exposing the data we need to ruby and doing the logging outside of the C extension.

## Solution

This PR is purely a refactor, so just moves the logging to a private Rotoscope#log_call ruby method.  A follow-up PR will allow the application to specify the logging method and make sure we have expose methods needed for filtering.

All the logging or even knowledge about the IO object has been removed from the C code in this PR.  Instead, the Rotoscope C struct is used to store the data needed for logging and these are exposed through protected ruby methods defined in C.

The logging logic was moved into lib/rotoscope.rb which provides backwards compatibility.

- [x] `bin/fmt` was successfully run