### PR TITLE
Drop use of -Werror when compiling for Linux support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+env:
+  - ROTOSCOPE_COMPILE_ERROR=1

--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,9 @@
 ---
 name: rotoscope
+
+env:
+  ROTOSCOPE_COMPILE_ERROR: '1'
+
 up:
   - ruby: 2.4.3
   - homebrew:

--- a/ext/rotoscope/extconf.rb
+++ b/ext/rotoscope/extconf.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 require "mkmf"
 
-$CFLAGS << ' -std=c99 -Wall -Werror -Wno-declaration-after-statement'
+$CFLAGS << ' -std=c99'
+$CFLAGS << ' -Wall'
+$CFLAGS << ' -Wno-declaration-after-statement'
+
+unless ['0', '', nil].include?(ENV['ROTOSCOPE_COMPILE_ERROR'])
+  $CFLAGS << ' -Werror'
+end
+
 $defs << "-D_POSIX_SOURCE"
 
 create_makefile('rotoscope/rotoscope')

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -79,7 +79,7 @@ class RotoscopeTest < MiniTest::Test
   end
 
   def test_new
-    rs = Rotoscope::CallLogger.new(@logfile, blacklist: ['tmp'])
+    rs = Rotoscope::CallLogger.new(@logfile, blacklist: %w(tmp))
     assert rs.is_a?(Rotoscope::CallLogger)
   end
 


### PR DESCRIPTION
Running `docker run -it --rm ruby:2.4.4 gem install rotoscope -v 0.3.0.pre.8` fails due to the `-Werror` flag failing to compile `ruby.h`.

```
root@f7fd5e6342d4:/app# gem install rotoscope -v 0.3.0.pre.8
Building native extensions. This could take a while...
ERROR:  Error installing rotoscope:
    ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/rotoscope-0.3.0.pre.8/ext/rotoscope
/usr/local/bin/ruby -r ./siteconf20180614-9454-1vzcc00.rb extconf.rb
creating Makefile

current directory: /usr/local/bundle/gems/rotoscope-0.3.0.pre.8/ext/rotoscope
make "DESTDIR=" clean

current directory: /usr/local/bundle/gems/rotoscope-0.3.0.pre.8/ext/rotoscope
make "DESTDIR="
compiling callsite.c
compiling method_desc.c
compiling rotoscope.c
In file included from /usr/local/include/ruby-2.4.0/ruby/ruby.h:2012:0,
                 from /usr/local/include/ruby-2.4.0/ruby.h:33,
                 from rotoscope.c:2:
/usr/local/include/ruby-2.4.0/ruby/intern.h:910:29: error: 'struct timespec' declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
 void rb_timespec_now(struct timespec *);
                             ^~~~~~~~
/usr/local/include/ruby-2.4.0/ruby/intern.h:913:41: error: 'struct timespec' declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
 VALUE rb_time_timespec_new(const struct timespec *, int);
                                         ^~~~~~~~
cc1: error: unrecognized command line option '-Wno-self-assign' [-Werror]
cc1: error: unrecognized command line option '-Wno-constant-logical-operand' [-Werror]
cc1: error: unrecognized command line option '-Wno-parentheses-equality' [-Werror]
cc1: all warnings being treated as errors
Makefile:242: recipe for target 'rotoscope.o' failed
make: *** [rotoscope.o] Error 1

make failed, exit code 2

Gem files will remain installed in /usr/local/bundle/gems/rotoscope-0.3.0.pre.8 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux/2.4.0/rotoscope-0.3.0.pre.8/gem_make.out
```

This PR drops the use of the flag unless it is being compiled via `dev`.

---

Solution taken from https://github.com/Shopify/bootsnap/issues/15 and https://github.com/Shopify/bootsnap/commit/cb4606f3ceb5c7c19d34fd1a14c0c7e83072e58e.