### PR TITLE
Remove unused trace_arg parameter to the ruby_callsite C function

### DIFF
--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -12,7 +12,7 @@ rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg) {
   };
 }
 
-rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg) {
+rs_callsite_t ruby_callsite() {
   VALUE frames[2];
   int lines[2];
   // There is currently a bug in rb_profile_frames that

--- a/ext/rotoscope/callsite.h
+++ b/ext/rotoscope/callsite.h
@@ -12,6 +12,6 @@ typedef struct {
 void init_callsite();
 
 rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg);
-rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg);
+rs_callsite_t ruby_callsite();
 
 #endif

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -49,7 +49,7 @@ static rs_callsite_t tracearg_path(rb_trace_arg_t *trace_arg) {
     case RUBY_EVENT_C_CALL:
       return c_callsite(trace_arg);
     default:
-      return ruby_callsite(trace_arg);
+      return ruby_callsite();
   }
 }
 


### PR DESCRIPTION
It uses rb_profile_frames so doesn't need trace_arg

- [x] `bin/fmt` was successfully run