### PR TITLE
Make diffs in test failures easier to read

### DIFF
--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -488,9 +488,11 @@ class RotoscopeTest < MiniTest::Test
 
   private
 
+  EXPECTATION_ORDER = [:entity, :method_name, :method_level, :filepath, :lineno, :caller_entity, :caller_method_name, :caller_method_level]
+
   def parse_and_normalize(csv_string)
     CSV.parse(csv_string, headers: true, header_converters: :symbol).map do |row|
-      row = row.to_h
+      row = row.to_a.sort_by { |name, _| EXPECTATION_ORDER.index(name) }.to_h
       row[:lineno] = -1
       row[:filepath] = File.expand_path(row[:filepath]).gsub(ROOT_FIXTURE_PATH, '')
       row[:entity] = row[:entity].gsub(/:0x[a-fA-F0-9]{4,}/m, ":0xXXXXXX")
@@ -510,6 +512,8 @@ class RotoscopeTest < MiniTest::Test
     File.open(path) { |f| Zlib::GzipReader.new(f).read }
   end
 end
+
+Minitest::Test.make_my_diffs_pretty!
 
 # https://github.com/seattlerb/minitest/pull/683 needed to use
 # autorun without affecting the exit status of forked processes


### PR DESCRIPTION
## Problem

The test failures can be hard to read to see what actual failed.  E.g. can you tell where the mismatch is on a test failure like

```
  1) Failure:
RotoscopeTest#test_flatten [/Users/dylansmith/src/rotoscope/test/rotoscope_test.rb:137]:
--- expected
+++ actual
@@ -1 +1 @@
-[{:entity=>"Example", :method_name=>"new", :method_level=>"instance", :filepath=>"/rotoscope_test.rb", :lineno=>-1, :caller_entity=>"<ROOT>", :caller_method_name=>"<UNKNOWN>", :caller_method_level=>"<UNKNOWN>"}, {:entity=>"Example", :method_name=>"initialize", :method_level=>"instance", :filepath=>"/rotoscope_test.rb", :lineno=>-1, :caller_entity=>"Example", :caller_method_name=>"new", :caller_method_level=>"class"}, {:entity=>"Example", :method_name=>"normal_method", :method_level=>"instance", :filepath=>"/rotoscope_test.rb", :lineno=>-1, :caller_entity=>"<ROOT>", :caller_method_name=>"<UNKNOWN>", :caller_method_level=>"<UNKNOWN>"}]
+[{:entity=>"Example", :caller_entity=>"<ROOT>", :filepath=>"/rotoscope_test.rb", :lineno=>-1, :method_name=>"new", :method_level=>"class", :caller_method_name=>"<UNKNOWN>", :caller_method_level=>"<UNKNOWN>"}, {:entity=>"Example", :caller_entity=>"Example", :filepath=>"/rotoscope_test.rb", :lineno=>-1, :method_name=>"initialize", :method_level=>"instance", :caller_method_name=>"new", :caller_method_level=>"class"}, {:entity=>"Example", :caller_entity=>"<ROOT>", :filepath=>"/rotoscope_test.rb", :lineno=>-1, :method_name=>"normal_method", :method_level=>"instance", :caller_method_name=>"<UNKNOWN>", :caller_method_level=>"<UNKNOWN>"}]
```

## Solution

Reorder the hash keys to match the order we have been using in the test expectations.  Then use `Minitest::Test.make_my_diffs_pretty!` to have minitest do a diff on the pretty printing of the expected and actual objects.

E.g. instead of getting the error shown above, it would instead get

```
  1) Failure:
RotoscopeTest#test_flatten [/Users/dylansmith/src/rotoscope/test/rotoscope_test.rb:137]:
--- expected
+++ actual
@@ -1,6 +1,6 @@
 [{:entity=>"Example",
   :method_name=>"new",
-  :method_level=>"instance",
+  :method_level=>"class",
   :filepath=>"/rotoscope_test.rb",
   :lineno=>-1,
   :caller_entity=>"<ROOT>",
```

- [x] `bin/fmt` was successfully run
