### PR TITLE
Replace empty string filepath default with nil

### DIFF
--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -2,13 +2,10 @@
 #include <ruby.h>
 #include <ruby/debug.h>
 
-VALUE empty_ruby_string;
-
 rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg) {
   VALUE path = rb_tracearg_path(trace_arg);
   return (rs_callsite_t){
-      .filepath = NIL_P(path) ? empty_ruby_string : path,
-      .lineno = FIX2INT(rb_tracearg_lineno(trace_arg)),
+      .filepath = path, .lineno = FIX2INT(rb_tracearg_lineno(trace_arg)),
   };
 }
 
@@ -21,17 +18,11 @@ rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg) {
   // frame.
   if (rb_profile_frames(0, 2, frames, lines) < 2) {
     return (rs_callsite_t){
-        .filepath = empty_ruby_string, .lineno = 0,
+        .filepath = Qnil, .lineno = 0,
     };
   }
 
   return (rs_callsite_t){
       .filepath = rb_profile_frame_path(frames[1]), .lineno = lines[1],
   };
-}
-
-void init_callsite() {
-  empty_ruby_string = rb_str_new_literal("");
-  RB_OBJ_FREEZE(empty_ruby_string);
-  rb_global_variable(&empty_ruby_string);
 }

--- a/ext/rotoscope/callsite.h
+++ b/ext/rotoscope/callsite.h
@@ -9,8 +9,6 @@ typedef struct {
   unsigned int lineno;
 } rs_callsite_t;
 
-void init_callsite();
-
 rs_callsite_t c_callsite(rb_trace_arg_t *trace_arg);
 rs_callsite_t ruby_callsite(rb_trace_arg_t *trace_arg);
 

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -315,6 +315,4 @@ void Init_rotoscope(void) {
                    rotoscope_caller_singleton_method_p, 0);
   rb_define_method(cRotoscope, "caller_path", rotoscope_caller_path, 0);
   rb_define_method(cRotoscope, "caller_lineno", rotoscope_caller_lineno, 0);
-
-  init_callsite();
 }

--- a/lib/rotoscope/call_logger.rb
+++ b/lib/rotoscope/call_logger.rb
@@ -88,7 +88,8 @@ class Rotoscope
     private
 
     def log_call(call)
-      return if blacklist.match?(call.caller_path)
+      caller_path = call.caller_path || ''
+      return if blacklist.match?(caller_path)
       return if self == call.receiver
 
       if call.caller_method_name.nil?
@@ -109,7 +110,7 @@ class Rotoscope
       buffer <<
         '"' << call.receiver_class_name << '",' \
         '"' << caller_class_name << '",' \
-        '"' << call.caller_path << '",' \
+        '"' << caller_path << '",' \
         << call.caller_lineno.to_s << ',' \
         '"' << method_name << '",' \
         << call_method_level << ',' \


### PR DESCRIPTION
Simplify the code a bit by using `nil` as the default filepath in the C code.  Instead, let the ruby code change that to an empty string.

- [x] `bin/fmt` was successfully run
