### PR TITLE
Prefer `match` for greater Ruby compatibility

### DIFF
--- a/lib/rotoscope/call_logger.rb
+++ b/lib/rotoscope/call_logger.rb
@@ -89,7 +89,7 @@ class Rotoscope
 
     def log_call(call)
       caller_path = call.caller_path || ''
-      return if blacklist.match?(caller_path)
+      return if blacklist.match(caller_path)
       return if self == call.receiver
 
       if call.caller_method_name.nil?


### PR DESCRIPTION
https://github.com/bbuchalter/rotoscope/blob/master/rotoscope.gemspec#L22 says this library supports Ruby versions greater than `2.2.0`, but `match?` was introduced in `2.4.0`. Let's use `match` here instead to support older versions of Ruby.

Make sure these are checked before submitting your PR — thank you!

- [x] `bin/fmt` was successfully run
