### PR TITLE
decrease number of columns of log header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 AllCops:
   Exclude:
     - 'tmp/**/*'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics/LineLength:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -70,21 +70,23 @@ IO,write,instance,example/dog.rb,11,IO,puts,instance
 
 #### `Rotoscope::CallLogger::trace(dest, blacklist: [])`
 
-Writes all calls of methods to `dest`, except for those whose filepath contains any entry in `blacklist`. `dest` is either a filename or an `IO`. Methods invoked at the top of the trace will have a caller entity of `<ROOT>` and a caller method name of `<UNKNOWN>`.
+Writes all calls of methods to `dest`, except for those whose filepath contains any entry in `blacklist`. `dest` is either a filename or an `IO`. Methods invoked at the top of the trace will have a caller entity of `<ROOT>` and a caller method name of `<UNKNOWN>`. You can also restrict which columns are included in the output by whitelisting them in `header`. By default all options are included.
 
 ```ruby
 Rotoscope::CallLogger.trace(dest) { |rs| ... }
 # or...
-Rotoscope::CallLogger.trace(dest, blacklist: ["/.gem/"]) { |rs| ... }
+Rotoscope::CallLogger.trace(dest, blacklist: ["/.gem/"], header: [:filepath]) { |rs| ... }
 ```
 
-#### `Rotoscope::CallLogger::new(dest, blacklist: [])`
+#### `Rotoscope::CallLogger::new(dest, blacklist: [], header: [])`
 
 Same interface as `Rotoscope::CallLogger::trace`, but returns a `Rotoscope::CallLogger` instance, allowing fine-grain control via `Rotoscope::CallLogger#start_trace` and `Rotoscope::CallLogger#stop_trace`.
 ```ruby
 rs = Rotoscope::CallLogger.new(dest)
 # or...
 rs = Rotoscope::CallLogger.new(dest, blacklist: ["/.gem/"])
+# or 
+rs = Rotoscope::CallLogger.new(dest, header: [:filepath, :lineno])
 ```
 
 ---

--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -1,4 +1,5 @@
 #include "callsite.h"
+
 #include <ruby.h>
 #include <ruby/debug.h>
 #include <stdbool.h>

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -61,7 +61,9 @@ static rs_method_desc_t called_method_desc(rb_trace_arg_t *trace_arg) {
       SYM2ID(method_id) != id_initialize;
 
   return (rs_method_desc_t){
-      .receiver = receiver, .id = method_id, .singleton_p = singleton_p,
+      .receiver = receiver,
+      .id = method_id,
+      .singleton_p = singleton_p,
   };
 }
 
@@ -153,7 +155,10 @@ static VALUE rs_alloc(VALUE klass) {
   config->tracing = false;
   config->caller = NULL;
   config->callsite = (rs_callsite_t){
-      .filepath = Qnil, .lineno = 0, .method_name = Qnil, .singleton_p = Qnil,
+      .filepath = Qnil,
+      .lineno = 0,
+      .method_name = Qnil,
+      .singleton_p = Qnil,
   };
   config->trace_proc = Qnil;
   rs_stack_init(&config->stack, STACK_CAPACITY);

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -2,6 +2,7 @@
 #define _INC_ROTOSCOPE_H_
 
 #include <unistd.h>
+
 #include "stack.h"
 
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -1,7 +1,9 @@
 #include "stack.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "ruby.h"
 
 static void resize_buffer(rs_stack_t *stack) {

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -1,9 +1,12 @@
 #ifndef _INC_ROTOSCOPE_STACK_H_
 #define _INC_ROTOSCOPE_STACK_H_
 #include <stdbool.h>
+
 #include "method_desc.h"
 
-typedef struct { rs_method_desc_t method; } rs_stack_frame_t;
+typedef struct {
+  rs_method_desc_t method;
+} rs_stack_frame_t;
 
 typedef struct {
   int capacity;

--- a/lib/rotoscope/call_logger.rb
+++ b/lib/rotoscope/call_logger.rb
@@ -101,6 +101,22 @@ class Rotoscope
 
     private
 
+    def log_call(call)
+      return if blacklist.match?(filepath(call))
+      return if self == call.receiver
+
+      buffer = @output_buffer
+      buffer.clear
+
+      if @header.size > 1
+        @header[0...-1].each do |head|
+          buffer << '"' << send(head, call) << '",'
+        end
+      end
+      buffer << send(@header.last, call) << "\n"
+      io.write(buffer)
+    end
+
     def entity(call)
       call.receiver_class_name
     end
@@ -139,23 +155,6 @@ class Rotoscope
       else
         call.caller_singleton_method? ? 'class' : 'instance'
       end
-    end
-
-    def log_call(call)
-      return if blacklist.match?(filepath(call))
-      return if self == call.receiver
-
-      buffer = @output_buffer
-      buffer.clear
-
-      # TODO: check for last line
-      if @header.size > 1
-        @header[0...-1].each do |head|
-          buffer << '"' << send(head, call) << '",'
-        end
-      end
-      buffer << send(@header.last, call) << "\n"
-      io.write(buffer)
     end
 
     def escape_csv_string(string)

--- a/test/monadify.rb
+++ b/test/monadify.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Monadify
   def self.extended(base)
     base.define_singleton_method("contents=") { |val| val }

--- a/test/rotoscope_test.rb
+++ b/test/rotoscope_test.rb
@@ -173,7 +173,7 @@ class RotoscopeTest < MiniTest::Test
     assert_equal([
       { entity: "Example", method_name: "new" },
       { entity: "Example", method_name: "initialize" },
-      { entity: "Example", method_name: "normal_method" }
+      { entity: "Example", method_name: "normal_method" },
     ], parse_and_normalize(contents))
   end
 


### PR DESCRIPTION
This PR adds the ability to restrict which columns are included in the output of the trace.
This is useful to us as we won't need to parse and filter the output, which slows us down quite a bit.

The changes to the C files were made by rubocop after running `bin/fmt`

- [x] `bin/fmt` was successfully run
