### PR TITLE
bin/fmt with upgraded rubocop and clang-format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_from:
 AllCops:
   Exclude:
     - 'tmp/**/*'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics/LineLength:
   Exclude:

--- a/ext/rotoscope/callsite.c
+++ b/ext/rotoscope/callsite.c
@@ -1,4 +1,5 @@
 #include "callsite.h"
+
 #include <ruby.h>
 #include <ruby/debug.h>
 #include <stdbool.h>

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -1,7 +1,6 @@
 #include "rotoscope.h"
 
 #include <errno.h>
-#include <ruby.h>
 #include <ruby/debug.h>
 #include <ruby/intern.h>
 #include <ruby/io.h>
@@ -10,7 +9,6 @@
 #include <stdio.h>
 #include <sys/file.h>
 
-#include "callsite.h"
 #include "method_desc.h"
 #include "stack.h"
 

--- a/ext/rotoscope/rotoscope.c
+++ b/ext/rotoscope/rotoscope.c
@@ -1,3 +1,5 @@
+#include "rotoscope.h"
+
 #include <errno.h>
 #include <ruby.h>
 #include <ruby/debug.h>
@@ -10,7 +12,6 @@
 
 #include "callsite.h"
 #include "method_desc.h"
-#include "rotoscope.h"
 #include "stack.h"
 
 VALUE cRotoscope, cTracePoint;
@@ -61,7 +62,9 @@ static rs_method_desc_t called_method_desc(rb_trace_arg_t *trace_arg) {
       SYM2ID(method_id) != id_initialize;
 
   return (rs_method_desc_t){
-      .receiver = receiver, .id = method_id, .singleton_p = singleton_p,
+      .receiver = receiver,
+      .id = method_id,
+      .singleton_p = singleton_p,
   };
 }
 
@@ -153,7 +156,10 @@ static VALUE rs_alloc(VALUE klass) {
   config->tracing = false;
   config->caller = NULL;
   config->callsite = (rs_callsite_t){
-      .filepath = Qnil, .lineno = 0, .method_name = Qnil, .singleton_p = Qnil,
+      .filepath = Qnil,
+      .lineno = 0,
+      .method_name = Qnil,
+      .singleton_p = Qnil,
   };
   config->trace_proc = Qnil;
   rs_stack_init(&config->stack, STACK_CAPACITY);

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -1,8 +1,10 @@
 #ifndef _INC_ROTOSCOPE_H_
 #define _INC_ROTOSCOPE_H_
 
+#include <ruby.h>
 #include <unistd.h>
 
+#include "callsite.h"
 #include "stack.h"
 
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)

--- a/ext/rotoscope/rotoscope.h
+++ b/ext/rotoscope/rotoscope.h
@@ -2,6 +2,7 @@
 #define _INC_ROTOSCOPE_H_
 
 #include <unistd.h>
+
 #include "stack.h"
 
 #define EVENT_CALL (RUBY_EVENT_CALL | RUBY_EVENT_C_CALL)

--- a/ext/rotoscope/stack.c
+++ b/ext/rotoscope/stack.c
@@ -1,7 +1,9 @@
 #include "stack.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "ruby.h"
 
 static void resize_buffer(rs_stack_t *stack) {

--- a/ext/rotoscope/stack.h
+++ b/ext/rotoscope/stack.h
@@ -1,9 +1,12 @@
 #ifndef _INC_ROTOSCOPE_STACK_H_
 #define _INC_ROTOSCOPE_STACK_H_
 #include <stdbool.h>
+
 #include "method_desc.h"
 
-typedef struct { rs_method_desc_t method; } rs_stack_frame_t;
+typedef struct {
+  rs_method_desc_t method;
+} rs_stack_frame_t;
 
 typedef struct {
   int capacity;

--- a/test/monadify.rb
+++ b/test/monadify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Monadify
   def self.extended(base)
     base.define_singleton_method("contents=") { |val| val }


### PR DESCRIPTION
We can still use the file formatting from #80 even though it was closed regarding the main purpose for the PR.

Target ruby version changed to 2.2 for rubocop since it doesn't support older versions anymore.

clang-format moved the rotoscope.h include to the top of the C file, which exposed some missing dependencies in rotoscope.h which I fixed in the second commit.