### PR TITLE
Add version constraint to ruby_memcheck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 
 gem "rubocop", "~> 1.22", require: false
 gem "rubocop-shopify", "~> 2.3.0", require: false
-gem "ruby_memcheck", require: false
+gem "ruby_memcheck", "~> 0.1.2", require: false


### PR DESCRIPTION
`bundle exec rake test:valgrind` started failing with `Nokogiri::XML::SyntaxError: 1132109:1: FATAL: Extra content at the end of the document` errors (e.g. https://github.com/Shopify/rotoscope/runs/4000221076?check_suite_focus=true).

This started with ruby_memcheck 0.2.1, so I've added a version constraint to avoid automatically updating that gem for now.