### PR TITLE
Use Valgrind suppression files for TracePoint leak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 
 gem "rubocop", "~> 1.22", require: false
 gem "rubocop-shopify", "~> 2.3.0", require: false
-gem "ruby_memcheck", "~> 0.1.2", require: false
+gem "ruby_memcheck", "~> 0.3.0", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -33,12 +33,7 @@ end
 require "rake/testtask"
 require "ruby_memcheck"
 
-RubyMemcheck.config(
-  binary_name: "rotoscope",
-  skipped_ruby_functions: RubyMemcheck::Configuration::DEFAULT_SKIPPED_RUBY_FUNCTIONS + [
-    /\Arb_tracepoint_new\z/, # TODO: Fix this upstream ruby bug
-  ],
-)
+RubyMemcheck.config(binary_name: "rotoscope")
 
 test_config = lambda do |t|
   t.test_files = FileList["test/*_test.rb"]

--- a/suppressions/rotoscope_ruby-2.7.supp
+++ b/suppressions/rotoscope_ruby-2.7.supp
@@ -1,0 +1,9 @@
+{
+  Memory leak in Ruby for versions <= 2.7.4 (see https://bugs.ruby-lang.org/issues/18264)
+  Memcheck:Leak
+  ...
+  fun:tp_alloc
+  fun:tracepoint_new
+  fun:rb_tracepoint_new
+  ...
+}

--- a/suppressions/rotoscope_ruby-3.0.supp
+++ b/suppressions/rotoscope_ruby-3.0.supp
@@ -1,0 +1,9 @@
+{
+  Memory leak in Ruby for versions <= 3.0.2 (see https://bugs.ruby-lang.org/issues/18264)
+  Memcheck:Leak
+  ...
+  fun:tp_alloc
+  fun:tracepoint_new
+  fun:rb_tracepoint_new
+  ...
+}


### PR DESCRIPTION
TracePoint memory leak was fixed in https://bugs.ruby-lang.org/issues/18264.
Suppress the memory leak for only Ruby 2.7 and 3.0. ruby_memcheck
now supports Valgrind suppression files based on version numbers.

Make sure these are checked before submitting your PR — thank you!

- [x] `bin/fmt` was successfully run
