### PR TITLE
Standardize dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,15 @@ updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+      time: "14:00"
+    open-pull-requests-limit: 100
     insecure-external-code-execution: allow
     registries: "*"
+    groups:
+      minor-gem-update:
+        update-types:
+          - "minor"
+      patch-gem-update:
+        update-types:
+          - "patch"


### PR DESCRIPTION
- [x] `bin/fmt` was successfully run

Bring this repo in line with other repos with support